### PR TITLE
No HDMI option for fast test builds

### DIFF
--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -576,6 +576,7 @@ wire         vbuf_write;
 wire  [23:0] hdmi_data;
 wire         hdmi_vs, hdmi_hs, hdmi_de;
 
+`ifndef MISTER_NOHDMI
 ascal 
 #(
 	.RAMBASE(32'h20000000),
@@ -653,6 +654,7 @@ ascal
 	.avl_read         (vbuf_read),
 	.avl_byteenable   (vbuf_byteenable)
 );
+`endif
 
 reg        FB_EN     = 0;
 reg        FB_FLT    = 0;
@@ -750,7 +752,7 @@ end
 
 
 /////////////////////////  HDMI output  /////////////////////////////////
-
+`ifndef MISTER_NOHDMI
 wire hdmi_clk_out;
 pll_hdmi pll_hdmi
 (
@@ -760,6 +762,9 @@ pll_hdmi pll_hdmi
 	.reconfig_from_pll(reconfig_from_pll),
 	.outclk_0(hdmi_clk_out)
 );
+`else
+assign hdmi_clk_out = 0;
+`endif
 
 //1920x1080@60 PCLK=148.5MHz CEA
 reg  [11:0] WIDTH  = 1920;
@@ -781,6 +786,7 @@ reg         adj_write;
 reg   [5:0] adj_address;
 reg  [31:0] adj_data;
 
+`ifndef MISTER_NOHDMI
 pll_cfg pll_cfg
 (
 	.mgmt_clk(FPGA_CLK1_50),
@@ -794,6 +800,7 @@ pll_cfg pll_cfg
 	.reconfig_to_pll(reconfig_to_pll),
 	.reconfig_from_pll(reconfig_from_pll)
 );
+`endif
 
 reg cfg_ready = 0;
 
@@ -826,6 +833,7 @@ always @(posedge FPGA_CLK1_50) begin
 end
 
 wire hdmi_config_done;
+`ifndef MISTER_NOHDMI
 hdmi_config hdmi_config
 (
 	.iCLK(FPGA_CLK1_50),
@@ -840,6 +848,9 @@ hdmi_config hdmi_config
 	.limited(hdmi_limited),
 	.ypbpr(ypbpr_en & direct_video)
 );
+`else
+assign hdmi_config_done = 1;
+`endif
 
 wire [23:0] hdmi_data_sl;
 wire        hdmi_de_sl, hdmi_vs_sl, hdmi_hs_sl;
@@ -861,6 +872,7 @@ scanlines #(1) HDMI_scanlines
 
 wire [23:0] hdmi_data_osd;
 wire        hdmi_de_osd, hdmi_vs_osd, hdmi_hs_osd;
+`ifndef MISTER_NOHDMI
 osd hdmi_osd
 (
 	.clk_sys(clk_sys),
@@ -884,6 +896,7 @@ osd hdmi_osd
 	.osd_status(osd_status)
 `endif
 );
+`endif
 
 wire hdmi_cs_osd;
 csync csync_hdmi(clk_hdmi, hdmi_hs_osd, hdmi_vs_osd, hdmi_cs_osd);
@@ -929,6 +942,7 @@ always @(posedge clk_vid) begin
 	dv_vs  <= dv_vs2;
 end
 
+`ifndef MISTER_NOHDMI
 wire hdmi_tx_clk;
 cyclonev_clkselect hdmi_clk_sw
 ( 
@@ -986,6 +1000,7 @@ assign HDMI_TX_HS = hdmi_out_hs;
 assign HDMI_TX_VS = hdmi_out_vs;
 assign HDMI_TX_DE = hdmi_out_de;
 assign HDMI_TX_D  = hdmi_out_d;
+`endif
 
 /////////////////////////  VGA output  //////////////////////////////////
 
@@ -1149,6 +1164,7 @@ wire        alsa_late;
 
 wire [15:0] alsa_l, alsa_r;
 
+`ifndef MISTER_NOHDMI
 alsa alsa
 (
 	.reset(reset),
@@ -1167,7 +1183,10 @@ alsa alsa
 	.pcm_l(alsa_l),
 	.pcm_r(alsa_r)
 );
-
+`else
+assign alsa_l = 16'd0;
+assign alsa_r = 16'd0;
+`endif
 
 ////////////////  User I/O (USB 3.0 connector) /////////////////////////
 


### PR DESCRIPTION
By defining MISTER_NOHDMI all HDMI related modules will not be compiled. This speeds up compilation by 30~40%. Useful for test runs.