### PR TITLE
Video rotation limited to 12 bits per pixel

### DIFF
--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -575,13 +575,9 @@ wire         vbuf_write;
 wire  [23:0] hdmi_data;
 wire         hdmi_vs, hdmi_hs, hdmi_de;
 
-<<<<<<< HEAD
 `ifndef DEBUG_NOHDMI
 wire clk_hdmi  = hdmi_clk_out;
 
-=======
-`ifndef MISTER_NOHDMI
->>>>>>> mine
 ascal 
 #(
 	.RAMBASE(32'h20000000),
@@ -760,11 +756,7 @@ end
 
 
 /////////////////////////  HDMI output  /////////////////////////////////
-<<<<<<< HEAD
 `ifndef DEBUG_NOHDMI
-=======
-`ifndef MISTER_NOHDMI
->>>>>>> mine
 wire hdmi_clk_out;
 pll_hdmi pll_hdmi
 (
@@ -774,11 +766,6 @@ pll_hdmi pll_hdmi
 	.reconfig_from_pll(reconfig_from_pll),
 	.outclk_0(hdmi_clk_out)
 );
-<<<<<<< HEAD
-=======
-`else
-assign hdmi_clk_out = 0;
->>>>>>> mine
 `endif
 
 //1920x1080@60 PCLK=148.5MHz CEA
@@ -801,11 +788,7 @@ reg         adj_write;
 reg   [5:0] adj_address;
 reg  [31:0] adj_data;
 
-<<<<<<< HEAD
 `ifndef DEBUG_NOHDMI
-=======
-`ifndef MISTER_NOHDMI
->>>>>>> mine
 pll_cfg pll_cfg
 (
 	.mgmt_clk(FPGA_CLK1_50),
@@ -819,7 +802,6 @@ pll_cfg pll_cfg
 	.reconfig_to_pll(reconfig_to_pll),
 	.reconfig_from_pll(reconfig_from_pll)
 );
-`endif
 
 reg cfg_got = 0;
 always @(posedge clk_sys) begin
@@ -868,7 +850,6 @@ wire cfg_ready = 1;
 `endif
 
 wire hdmi_config_done;
-`ifndef MISTER_NOHDMI
 hdmi_config hdmi_config
 (
 	.iCLK(FPGA_CLK1_50),
@@ -883,9 +864,6 @@ hdmi_config hdmi_config
 	.limited(hdmi_limited),
 	.ypbpr(ypbpr_en & direct_video)
 );
-`else
-assign hdmi_config_done = 1;
-`endif
 
 `ifndef DEBUG_NOHDMI
 wire [23:0] hdmi_data_sl;
@@ -908,11 +886,7 @@ scanlines #(1) HDMI_scanlines
 
 wire [23:0] hdmi_data_osd;
 wire        hdmi_de_osd, hdmi_vs_osd, hdmi_hs_osd;
-<<<<<<< HEAD
 
-=======
-`ifndef MISTER_NOHDMI
->>>>>>> mine
 osd hdmi_osd
 (
 	.clk_sys(clk_sys),
@@ -982,7 +956,6 @@ always @(posedge clk_vid) begin
 	dv_vs  <= dv_vs2;
 end
 
-`ifndef MISTER_NOHDMI
 wire hdmi_tx_clk;
 `ifndef DEBUG_NOHDMI
 cyclonev_clkselect hdmi_clk_sw
@@ -1044,7 +1017,6 @@ assign HDMI_TX_HS = hdmi_out_hs;
 assign HDMI_TX_VS = hdmi_out_vs;
 assign HDMI_TX_DE = hdmi_out_de;
 assign HDMI_TX_D  = hdmi_out_d;
-`endif
 
 /////////////////////////  VGA output  //////////////////////////////////
 
@@ -1208,7 +1180,6 @@ wire        alsa_late;
 
 wire [15:0] alsa_l, alsa_r;
 
-`ifndef MISTER_NOHDMI
 alsa alsa
 (
 	.reset(reset),
@@ -1227,13 +1198,6 @@ alsa alsa
 	.pcm_l(alsa_l),
 	.pcm_r(alsa_r)
 );
-<<<<<<< HEAD
-=======
-`else
-assign alsa_l = 16'd0;
-assign alsa_r = 16'd0;
-`endif
->>>>>>> mine
 
 ////////////////  User I/O (USB 3.0 connector) /////////////////////////
 


### PR DESCRIPTION
arcade_video can handle upto 24 bits per pixel but given the size of the MiSTer FPGA the rotation module cannot really be used for 24 bpp images. For instance, a 384x224 image at 24bpp needs a 252kBx2=504kB memory buffer.
It is true that for a very low resolution it would be possible to handle 24bpp but I cannot think of any case that needs screen rotation at 24bpp and doesn't have a similar resolution to ~384x224.
24bpp output is left intact for the non-rotated output.
The changes have been tested with 24bpp and 12bpp inputs before the PR.