### PR TITLE
ACMD23 response added in sd_card.sv

### DIFF
--- a/sys/sd_card.sv
+++ b/sys/sd_card.sv
@@ -361,6 +361,8 @@ always @(posedge clk_spi) begin
 
 					// CMD18: READ_MULTIPLE
 					'h52: reply <= 0;    // ok
+					// ACMD23:  SET_WR_BLK_ERASE_COUNT
+					'h57: reply <= 0;     //ok
 
 					// CMD24: WRITE_BLOCK
 					'h58,


### PR DESCRIPTION
Mullti block writes were not working on the MSX1 core. The driver was sending ACM23 and was falling. so no writes after that.
