### PR TITLE
audio frames marked as copy permitted 48kHz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ c5_pin_model_dump.txt
 *.xml
 *_netlist
 *.cdf
+**/.DS_Store

--- a/sys/spdif.v
+++ b/sys/spdif.v
@@ -67,6 +67,8 @@ reg         spdif_out_q;
 
 reg [5:0]   parity_count_q;
 
+reg         channel_status_bit;
+
 //-----------------------------------------------------------------
 // Subframe Counter
 //-----------------------------------------------------------------
@@ -142,7 +144,7 @@ assign subframe_w[28] = 1'b0; // Valid
 assign subframe_w[29] = 1'b0;
 
 // Timeslots 30 = Channel status bit
-assign subframe_w[30] = 1'b0;
+assign subframe_w[30] = channel_status_bit ; //was constant 1'b0 enabling copy-bit;
 
 // Timeslots 31 = Even Parity bit (31:4)
 assign subframe_w[31] = 1'b0;
@@ -150,9 +152,9 @@ assign subframe_w[31] = 1'b0;
 //-----------------------------------------------------------------
 // Preamble
 //-----------------------------------------------------------------
-localparam PREAMBLE_Z = 8'b00010111;
-localparam PREAMBLE_Y = 8'b00100111;
-localparam PREAMBLE_X = 8'b01000111;
+localparam PREAMBLE_Z = 8'b00010111; // "B" channel A data at start of block
+localparam PREAMBLE_Y = 8'b00100111; // "W" channel B data
+localparam PREAMBLE_X = 8'b01000111; // "M" channel A data not at start of block
 
 reg [7:0] preamble_r;
 
@@ -168,6 +170,15 @@ begin
     // Left Channel (but not start of block)?
     else
         preamble_r = PREAMBLE_X; // X(M)
+
+    if (subframe_count_q[8:1] == 8'd2) // frame 2 => subframes 4 and 5 => 0 = copy inhibited, 1 = copy permitted
+        channel_status_bit = 1'b1;
+    else if (subframe_count_q[8:1] == 8'd15) // frame 15 => 0 = no indication, 1 = original media
+        channel_status_bit = 1'b1;
+    else if (subframe_count_q[8:1] == 8'd25) // frame 24 to 27 => sample frequency, 0100 = 48kHz, 0000 = 44kHz (l2r)
+        channel_status_bit = 1'b1;
+    else
+        channel_status_bit = 1'b0; // everything else defaults to 0        
 end
 
 always @ (posedge rst_i or posedge clk_i )


### PR DESCRIPTION
I noticed that MiSTer emits S/PDIF audio frames with all status bits zero.

According to [the specification](https://www.minidisc.org/spdif_c_channel.html) this leads to SCMS copy protection enabled, original recording flag being off and audio being reported as 44.1kHz.

In my case this meant that my USB sound card was unable to capture the audio. After the changes as part of the pull-request this is now no problem.

I tested it also on the Sega Genesis core and I confirm it is now all working with no negative effect on my other devices (TV, monitor, HDMI switch, etc.).

I suggest to make this fix part of the template core.

P.S. see [here](https://misterfpga.org/viewtopic.php?f=28&t=1803) for some additional screenshots