### PR TITLE
Fix breaking burst transaction on reset

### DIFF
--- a/sys/f2sdram_safe_terminator.sv
+++ b/sys/f2sdram_safe_terminator.sv
@@ -1,0 +1,251 @@
+// ============================================================================
+//
+//                f2sdram_safe_terminator for MiSTer platform
+//
+// ============================================================================
+// Copyright (c) 2021 bellwood420
+//
+// Background:
+//
+//   Terminating a transaction of burst writing(/reading) in its midstream
+//   seems to cause an illegal state to f2sdram interface.
+//
+//   Forced reset request that occurs when loading other core is inevitable.
+//
+//   So if it happens exactly within the transaction period,
+//   unexpected issues with accessing to f2sdram interface will be caused
+//   in next loaded core.
+//
+//   It seems that only way to reset broken f2sdram interface is to reset
+//   whole SDRAM Controller Subsystem from HPS via permodrst register
+//   in Reset Manager.
+//   But it cannot be done safely while Linux is running.
+//   It is usually done when cold or warm reset is issued in HPS.
+//
+//   Main_MiSTer is issuing reset for FPGA <> HPS bridges
+//   via brgmodrst register in Reset Manager when loading rbf.
+//   But it has no effect on f2sdram interface.
+//   f2sdram interface seems to belong to SDRAM Controller Subsystem
+//   rather than FPGA-to-HPS bridge.
+//
+//   Main_MiSTer is also trying to issuing reset for f2sdram ports
+//   via fpgaportrst register in SDRAM Controller Subsystem when loading rbf.
+//   But according to the Intel's document, fpgaportrst register can be
+//   used to strech the port reset.
+//   It seems that it cannot be used to assert the port reset.
+//
+//   According to the Intel's document, there seems to be a reset port on
+//   Avalon-MM slave interface, but it cannot be found in Qsys generated HDL.
+//
+//   To conclude, the only thing FPGA can do is not to break the transaction.
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//
+// Purpose:
+//   To prevent the issue, this module completes ongoing transaction
+//   on behalf of user logic, when reset is asserted.
+//
+// Usage:
+//   Insert this module into the bus line between
+//   f2sdram (Avalon-MM slave) and user logic (Avalon-MM master).
+//
+// Notice:
+//   Asynchronous reset request is not supported.
+//   Please feed reset request synchronized to clock.
+//
+module f2sdram_safe_terminator #(
+  parameter     ADDRESS_WITDH = 29,
+  parameter     DATA_WIDTH = 64,
+  parameter     BURSTCOUNT_WIDTH = 8,
+  parameter     BYTEENABLE_WIDTH = 8
+) (
+  // clk should be the same as one provided to f2sdram port
+  input         clk,
+  // rst_req_sync should be synchronized to clk
+  // Asynchronous reset request is not supported
+  input         rst_req_sync,
+
+  // Master port: connecting to Alavon-MM slave(f2sdram)
+  input                         waitrequest_master,
+  output [BURSTCOUNT_WIDTH-1:0] burstcount_master,
+  output    [ADDRESS_WITDH-1:0] address_master,
+  input        [DATA_WIDTH-1:0] readdata_master,
+  input                         readdatavalid_master,
+  output                        read_master,
+  output       [DATA_WIDTH-1:0] writedata_master,
+  output [BYTEENABLE_WIDTH-1:0] byteenable_master,
+  output                        write_master,
+
+  // Slave port: connecting to Alavon-MM master(user logic)
+  output                        waitrequest_slave,
+  input  [BURSTCOUNT_WIDTH-1:0] burstcount_slave,
+  input     [ADDRESS_WITDH-1:0] address_slave,
+  output       [DATA_WIDTH-1:0] readdata_slave,
+  output                        readdatavalid_slave,
+  input                         read_slave,
+  input        [DATA_WIDTH-1:0] writedata_slave,
+  input  [BYTEENABLE_WIDTH-1:0] byteenable_slave,
+  input                         write_slave
+);
+  /*
+   * Burst transaction observer
+   */
+  typedef enum reg [1:0] {
+    IDLE, READ, WRITE
+  } state_t;
+
+  state_t state = IDLE;
+  state_t next_state;
+
+  wire burst_start = state == IDLE  && (next_state == READ || next_state == WRITE);
+  wire read_data   = state == READ  && readdatavalid_master;
+  wire write_data  = state == WRITE && !waitrequest_master;
+  wire burst_end   = (state == READ || state == WRITE) && burstcounter == burstcount_latch - 'd1;
+  wire successful_non_burst_write = state == IDLE && write_slave && burstcount_slave == 'd1 && !waitrequest_master; 
+
+  reg [BURSTCOUNT_WIDTH-1:0] burstcounter       = 'd0;
+  reg [BURSTCOUNT_WIDTH-1:0] burstcount_latch   = 'd0;
+  reg [ADDRESS_WITDH-1:0]    address_latch      = 'd0;
+  reg [BYTEENABLE_WIDTH-1:0] byteenable_latch   = 'd0;
+  reg read_latch  = 1'b0;
+  reg write_latch = 1'b0;
+
+  always_ff @(posedge clk) begin
+    state <= next_state;
+
+    if (burst_start) begin
+      if (next_state == WRITE) begin
+        burstcounter <= waitrequest_master ? 'd0 :'d1;
+      end else if (next_state == READ) begin
+        burstcounter <= 'd0;
+      end
+
+      burstcount_latch <= burstcount_slave;
+      byteenable_latch <= byteenable_slave;
+      address_latch    <= address_slave;
+      read_latch       <= next_state == READ;
+      write_latch      <= next_state == WRITE;
+
+    end else if (read_data || write_data) begin
+      burstcounter <= burstcounter + 'd1;
+
+    end else if (burst_end) begin
+      read_latch  <= 1'b0;
+      write_latch <= 1'b0;
+    end
+  end
+
+  always_comb begin
+    case (state)
+      IDLE:     if (successful_non_burst_write)
+                  next_state <= IDLE;
+                else if (read_slave)
+                  next_state <= READ;
+                else if (write_slave)
+                  next_state <= WRITE;
+                else
+                  next_state <= IDLE;
+
+      READ:     if (burst_end)
+                  next_state <= IDLE;
+                else
+                  next_state <= READ;
+
+      WRITE:    if (burst_end)
+                  next_state <= IDLE;
+                else
+                  next_state <= WRITE;
+
+      default:  next_state <= IDLE;
+    endcase
+  end
+
+  /*
+   * Safe terminating
+   */
+  wire on_transaction = (state == READ || state == WRITE) && (next_state != IDLE);
+  reg terminating = 1'b0;
+  reg terminated = 1'b0;
+
+  reg [BURSTCOUNT_WIDTH-1:0] terminate_counter = 'd0;
+  reg [BURSTCOUNT_WIDTH-1:0] terminate_count = 'd0;
+  reg [ADDRESS_WITDH-1:0]    terminate_address_latch      = 'd0;
+  reg [BYTEENABLE_WIDTH-1:0] terminate_byteenable_latch   = 'd0;
+  reg terminate_read_latch  = 1'b0;
+  reg terminate_write_latch = 1'b0;
+
+  reg init_reset_deasserted = 1'b0;
+
+  always_ff @(posedge clk) begin
+    if (rst_req_sync) begin
+      // Reset assert
+      if (init_reset_deasserted) begin
+        if (on_transaction) begin
+          terminating <= 1'b1;
+          terminate_counter          <= burstcounter + 'd1;
+          terminate_count            <= burstcount_latch;
+          terminate_address_latch    <= address_latch;
+          terminate_byteenable_latch <= byteenable_latch;
+          terminate_read_latch       <= read_latch;
+          terminate_write_latch      <= write_latch;
+        end else begin
+          terminated = 1'b1;
+        end
+      end
+    end else begin
+      // Reset deassert
+      if (!terminating) begin
+        terminated <= 1'b0;
+      end
+      init_reset_deasserted <= 1'b1;
+    end
+
+    if (terminating) begin
+      // Continue read/write transaction until the end
+
+      if (terminate_read_latch && readdatavalid_master) begin
+        terminate_counter <= terminate_counter + 'd1;
+      end else if (terminate_write_latch && !waitrequest_master) begin
+        terminate_counter <= terminate_counter + 'd1;
+      end
+
+      if (terminate_counter == terminate_count - 'd1) begin
+        terminating <= 1'b0;
+        terminated <= 1'b1;
+      end
+    end
+  end
+
+  /*
+   * Bus mux depending on the stage.
+   */
+  always_comb begin
+    if (terminated) begin
+      burstcount_master = 'd1;
+      address_master    = 'd0;
+      read_master       = 'b0;
+      writedata_master  = 'd0;
+      byteenable_master = 'd0;
+      write_master      = 'b0;
+    end else if (terminating) begin
+      burstcount_master = burstcount_latch;
+      address_master    = terminate_address_latch;
+      read_master       = read_latch;
+      writedata_master  = 'd0;
+      byteenable_master = terminate_byteenable_latch;
+      write_master      = write_latch;
+    end else begin
+      burstcount_master = burstcount_slave;
+      address_master    = address_slave;
+      read_master       = read_slave;
+      writedata_master  = writedata_slave;
+      byteenable_master = byteenable_slave;
+      write_master      = write_slave;
+    end
+  end
+
+  // Just passing through master to slave
+  assign waitrequest_slave   = waitrequest_master;
+  assign readdata_slave      = readdata_master;
+  assign readdatavalid_slave = readdatavalid_master;
+
+endmodule

--- a/sys/sys.qip
+++ b/sys/sys.qip
@@ -27,3 +27,4 @@ set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) d
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) sysmem.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) sd_card.sv ]
 set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) hps_io.v ]
+set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) f2sdram_safe_terminator.sv ]

--- a/sys/sysmem.sv
+++ b/sys/sysmem.sv
@@ -44,41 +44,194 @@ module sysmem_lite
 
 assign reset_out = ~init_reset_n | ~hps_h2f_reset_n | reset_core_req;
 
+////////////////////////////////////////////////////////
+////          f2sdram_safe_terminator_ram1          ////
+////////////////////////////////////////////////////////
+wire  [28:0] f2h_ram1_address;
+wire   [7:0] f2h_ram1_burstcount;
+wire         f2h_ram1_waitrequest;
+wire  [63:0] f2h_ram1_readdata;
+wire         f2h_ram1_readdatavalid;
+wire         f2h_ram1_read;
+wire  [63:0] f2h_ram1_writedata;
+wire   [7:0] f2h_ram1_byteenable;
+wire         f2h_ram1_write;
+
+(* altera_attribute = {"-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS"} *) reg ram1_reset_0 = 1'b1;
+(* altera_attribute = {"-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS"} *) reg ram1_reset_1 = 1'b1;
+always @(posedge ram1_clk) begin
+  ram1_reset_0 <= reset_out;
+  ram1_reset_1 <= ram1_reset_0;
+end
+
+f2sdram_safe_terminator #(
+  .ADDRESS_WITDH(29),
+  .DATA_WIDTH(64),
+  .BURSTCOUNT_WIDTH(8),
+  .BYTEENABLE_WIDTH(8)
+) f2sdram_safe_terminator_ram1 (
+  .clk                      (ram1_clk),
+  .rst_req_sync             (ram1_reset_1),
+
+	.waitrequest_slave        (ram1_waitrequest),
+  .burstcount_slave         (ram1_burstcount),
+  .address_slave            (ram1_address),
+  .readdata_slave           (ram1_readdata),
+  .readdatavalid_slave      (ram1_readdatavalid),
+  .read_slave               (ram1_read),
+  .writedata_slave          (ram1_writedata),
+  .byteenable_slave         (ram1_byteenable),
+  .write_slave              (ram1_write),
+
+  .waitrequest_master       (f2h_ram1_waitrequest),
+  .burstcount_master        (f2h_ram1_burstcount),
+  .address_master           (f2h_ram1_address),
+  .readdata_master          (f2h_ram1_readdata),
+  .readdatavalid_master     (f2h_ram1_readdatavalid),
+  .read_master              (f2h_ram1_read),
+  .writedata_master         (f2h_ram1_writedata),
+  .byteenable_master        (f2h_ram1_byteenable),
+  .write_master             (f2h_ram1_write)
+);
+
+////////////////////////////////////////////////////////
+////          f2sdram_safe_terminator_ram2          ////
+////////////////////////////////////////////////////////
+wire  [28:0] f2h_ram2_address;
+wire   [7:0] f2h_ram2_burstcount;
+wire         f2h_ram2_waitrequest;
+wire  [63:0] f2h_ram2_readdata;
+wire         f2h_ram2_readdatavalid;
+wire         f2h_ram2_read;
+wire  [63:0] f2h_ram2_writedata;
+wire   [7:0] f2h_ram2_byteenable;
+wire         f2h_ram2_write;
+
+(* altera_attribute = {"-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS"} *) reg ram2_reset_0 = 1'b1;
+(* altera_attribute = {"-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS"} *) reg ram2_reset_1 = 1'b1;
+always @(posedge ram2_clk) begin
+  ram2_reset_0 <= reset_out;
+  ram2_reset_1 <= ram2_reset_0;
+end
+
+f2sdram_safe_terminator #(
+  .ADDRESS_WITDH(29),
+  .DATA_WIDTH(64),
+  .BURSTCOUNT_WIDTH(8),
+  .BYTEENABLE_WIDTH(8)
+) f2sdram_safe_terminator_ram2 (
+  .clk                      (ram2_clk),
+  .rst_req_sync             (ram2_reset_1),
+
+	.waitrequest_slave        (ram2_waitrequest),
+  .burstcount_slave         (ram2_burstcount),
+  .address_slave            (ram2_address),
+  .readdata_slave           (ram2_readdata),
+  .readdatavalid_slave      (ram2_readdatavalid),
+  .read_slave               (ram2_read),
+  .writedata_slave          (ram2_writedata),
+  .byteenable_slave         (ram2_byteenable),
+  .write_slave              (ram2_write),
+
+  .waitrequest_master       (f2h_ram2_waitrequest),
+  .burstcount_master        (f2h_ram2_burstcount),
+  .address_master           (f2h_ram2_address),
+  .readdata_master          (f2h_ram2_readdata),
+  .readdatavalid_master     (f2h_ram2_readdatavalid),
+  .read_master              (f2h_ram2_read),
+  .writedata_master         (f2h_ram2_writedata),
+  .byteenable_master        (f2h_ram2_byteenable),
+  .write_master             (f2h_ram2_write)
+);
+
+////////////////////////////////////////////////////////
+////          f2sdram_safe_terminator_vbuf          ////
+////////////////////////////////////////////////////////
+wire  [27:0] f2h_vbuf_address;
+wire   [7:0] f2h_vbuf_burstcount;
+wire         f2h_vbuf_waitrequest;
+wire [127:0] f2h_vbuf_readdata;
+wire         f2h_vbuf_readdatavalid;
+wire         f2h_vbuf_read;
+wire [127:0] f2h_vbuf_writedata;
+wire  [15:0] f2h_vbuf_byteenable;
+wire         f2h_vbuf_write;
+
+(* altera_attribute = {"-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS"} *) reg vbuf_reset_0 = 1'b1;
+(* altera_attribute = {"-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS"} *) reg vbuf_reset_1 = 1'b1;
+always @(posedge vbuf_clk) begin
+  vbuf_reset_0 <= reset_out;
+  vbuf_reset_1 <= vbuf_reset_0;
+end
+
+f2sdram_safe_terminator #(
+  .ADDRESS_WITDH(28),
+  .DATA_WIDTH(128),
+  .BURSTCOUNT_WIDTH(8),
+  .BYTEENABLE_WIDTH(16)
+) f2sdram_safe_terminator_vbuf (
+  .clk                      (vbuf_clk),
+  .rst_req_sync             (vbuf_reset_1),
+
+	.waitrequest_slave        (vbuf_waitrequest),
+  .burstcount_slave         (vbuf_burstcount),
+  .address_slave            (vbuf_address),
+  .readdata_slave           (vbuf_readdata),
+  .readdatavalid_slave      (vbuf_readdatavalid),
+  .read_slave               (vbuf_read),
+  .writedata_slave          (vbuf_writedata),
+  .byteenable_slave         (vbuf_byteenable),
+  .write_slave              (vbuf_write),
+
+  .waitrequest_master       (f2h_vbuf_waitrequest),
+  .burstcount_master        (f2h_vbuf_burstcount),
+  .address_master           (f2h_vbuf_address),
+  .readdata_master          (f2h_vbuf_readdata),
+  .readdatavalid_master     (f2h_vbuf_readdatavalid),
+  .read_master              (f2h_vbuf_read),
+  .writedata_master         (f2h_vbuf_writedata),
+  .byteenable_master        (f2h_vbuf_byteenable),
+  .write_master             (f2h_vbuf_write)
+);
+
+////////////////////////////////////////////////////////
+////             HPS <> FPGA interfaces             ////
+////////////////////////////////////////////////////////
 sysmem_HPS_fpga_interfaces fpga_interfaces (
 	.f2h_cold_rst_req_n       (~reset_hps_cold_req),
 	.f2h_warm_rst_req_n       (~reset_hps_warm_req),
 	.h2f_user0_clk            (clock),
 	.h2f_rst_n                (hps_h2f_reset_n),
 	.f2h_sdram0_clk           (vbuf_clk),
-	.f2h_sdram0_ADDRESS       (vbuf_address),
-	.f2h_sdram0_BURSTCOUNT    (vbuf_burstcount),
-	.f2h_sdram0_WAITREQUEST   (vbuf_waitrequest),
-	.f2h_sdram0_READDATA      (vbuf_readdata),
-	.f2h_sdram0_READDATAVALID (vbuf_readdatavalid),
-	.f2h_sdram0_READ          (vbuf_read),
-	.f2h_sdram0_WRITEDATA     (vbuf_writedata),
-	.f2h_sdram0_BYTEENABLE    (vbuf_byteenable),
-	.f2h_sdram0_WRITE         (vbuf_write),
+	.f2h_sdram0_ADDRESS       (f2h_vbuf_address),
+	.f2h_sdram0_BURSTCOUNT    (f2h_vbuf_burstcount),
+	.f2h_sdram0_WAITREQUEST   (f2h_vbuf_waitrequest),
+	.f2h_sdram0_READDATA      (f2h_vbuf_readdata),
+	.f2h_sdram0_READDATAVALID (f2h_vbuf_readdatavalid),
+	.f2h_sdram0_READ          (f2h_vbuf_read),
+	.f2h_sdram0_WRITEDATA     (f2h_vbuf_writedata),
+	.f2h_sdram0_BYTEENABLE    (f2h_vbuf_byteenable),
+	.f2h_sdram0_WRITE         (f2h_vbuf_write),
 	.f2h_sdram1_clk           (ram1_clk),
-	.f2h_sdram1_ADDRESS       (ram1_address),
-	.f2h_sdram1_BURSTCOUNT    (ram1_burstcount),
-	.f2h_sdram1_WAITREQUEST   (ram1_waitrequest),
-	.f2h_sdram1_READDATA      (ram1_readdata),
-	.f2h_sdram1_READDATAVALID (ram1_readdatavalid),
-	.f2h_sdram1_READ          (ram1_read),
-	.f2h_sdram1_WRITEDATA     (ram1_writedata),
-	.f2h_sdram1_BYTEENABLE    (ram1_byteenable),
-	.f2h_sdram1_WRITE         (ram1_write),
+	.f2h_sdram1_ADDRESS       (f2h_ram1_address),
+	.f2h_sdram1_BURSTCOUNT    (f2h_ram1_burstcount),
+	.f2h_sdram1_WAITREQUEST   (f2h_ram1_waitrequest),
+	.f2h_sdram1_READDATA      (f2h_ram1_readdata),
+	.f2h_sdram1_READDATAVALID (f2h_ram1_readdatavalid),
+	.f2h_sdram1_READ          (f2h_ram1_read),
+	.f2h_sdram1_WRITEDATA     (f2h_ram1_writedata),
+	.f2h_sdram1_BYTEENABLE    (f2h_ram1_byteenable),
+	.f2h_sdram1_WRITE         (f2h_ram1_write),
 	.f2h_sdram2_clk           (ram2_clk),
-	.f2h_sdram2_ADDRESS       (ram2_address),
-	.f2h_sdram2_BURSTCOUNT    (ram2_burstcount),
-	.f2h_sdram2_WAITREQUEST   (ram2_waitrequest),
-	.f2h_sdram2_READDATA      (ram2_readdata),
-	.f2h_sdram2_READDATAVALID (ram2_readdatavalid),
-	.f2h_sdram2_READ          (ram2_read),
-	.f2h_sdram2_WRITEDATA     (ram2_writedata),
-	.f2h_sdram2_BYTEENABLE    (ram2_byteenable),
-	.f2h_sdram2_WRITE         (ram2_write)
+	.f2h_sdram2_ADDRESS       (f2h_ram2_address),
+	.f2h_sdram2_BURSTCOUNT    (f2h_ram2_burstcount),
+	.f2h_sdram2_WAITREQUEST   (f2h_ram2_waitrequest),
+	.f2h_sdram2_READDATA      (f2h_ram2_readdata),
+	.f2h_sdram2_READDATAVALID (f2h_ram2_readdatavalid),
+	.f2h_sdram2_READ          (f2h_ram2_read),
+	.f2h_sdram2_WRITEDATA     (f2h_ram2_writedata),
+	.f2h_sdram2_BYTEENABLE    (f2h_ram2_byteenable),
+	.f2h_sdram2_WRITE         (f2h_ram2_write)
 );
 
 wire hps_h2f_reset_n;


### PR DESCRIPTION
### Background
Terminating a transaction of burst writing(/reading) in its midstream seems to cause an illegal state to f2sdram interface.

Forced reset request that occurs when loading other core is inevitable.

So if it happens exactly within the transaction period, unexpected various issues with accessing to f2sdram interface will be caused in next loaded core.
The period is intermittent and short, thus the issues will happen randomly while reloading core over and over.

e.g. 
Broken `f2h_sdram1` port (generic DDR interface provided to emu module) causes
- Boot freeze on Arcade-Cave core (https://github.com/MiSTer-devel/Arcade-Cave_MiSTer/issues/18)
- Corrupted vertical video on cores using `screen_rotate` module in sys

Broken `f2h_sdram0` port (used by ascal.vhd) causes
-  Corrupted scaler video output

### About resetting f2sdram interface
It seems that only way to reset broken f2sdram interface is to reset whole SDRAM Controller Subsystem from HPS via `permodrst` register in Reset Manager.
But it cannot be done safely while Linux is running.
It is usually done when cold or warm reset is issued in HPS.

Main_MiSTer is issuing reset for FPGA <> HPS bridges via `brgmodrst` register in Reset Manager when loading rbf.
But it has no effect on f2sdram interface.
f2sdram interface seems to belong to SDRAM Controller Subsystem rather than FPGA-to-HPS bridge.

Main_MiSTer is also trying to issuing reset for f2sdram ports via `fpgaportrst` register in SDRAM Controller Subsystem when loading rbf.
But according to the Intel's document, `fpgaportrst` register can be used to stretch the port reset.
It seems that it cannot be used to assert the port reset.

According to the Intel's document, there seems to be a reset port on Avalon-MM slave interface(not on Bidirectional port, but on Readonly/Writeonly port), but it cannot be found in Qsys generated HDL.

To conclude, the only thing FPGA can do is _not to break the transaction._

### Purpose
To prevent the issue, `f2sdram_safe_terminator` module completes ongoing transaction on behalf of forcibly reset　logic, when reset is asserted.