### PR TITLE
Addition of automatic horizontal scaling to ascal

### DIFF
--- a/mycore.sv
+++ b/mycore.sv
@@ -38,6 +38,8 @@ module emu
 	//Video aspect ratio for HDMI. Most retro systems have ratio 4:3.
 	output [11:0] VIDEO_ARX,
 	output [11:0] VIDEO_ARY,
+	
+	output [1:0] HORIZ_INT,	// horizontal integer scaling setting
 
 	output  [7:0] VGA_R,
 	output  [7:0] VGA_G,
@@ -197,12 +199,15 @@ wire [1:0] ar = status[9:8];
 
 assign VIDEO_ARX = (!ar) ? 12'd4 : (ar - 1'd1);
 assign VIDEO_ARY = (!ar) ? 12'd3 : 12'd0;
+	
+assign HORIZ_INT = status [11:10];
 
 `include "build_id.v" 
 localparam CONF_STR = {
 	"MyCore;;",
 	"-;",
 	"O89,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
+	"OAB,Intgr Hori Scale,Off,Narrow,Wide;",
 	"O2,TV Mode,NTSC,PAL;",
 	"O34,Noise,White,Red,Green,Blue;",
 	"-;",

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -317,6 +317,7 @@ reg  [8:0] coef_data;
 reg        coef_wr = 0;
 
 wire[11:0] ARX, ARY;
+wire[1:0] horiz_int;
 reg [11:0] VSET = 0, HSET = 0;
 reg        FREESCALE = 0;
 reg  [2:0] scaler_flt;
@@ -691,6 +692,7 @@ ascal
 	.hdisp    (WIDTH),
 	.hmin     (hmin),
 	.hmax     (hmax),
+	.h_int	  (horiz_int),
 	.vtotal   (HEIGHT + VFP + VBP + VS),
 	.vsstart  (HEIGHT + VFP),
 	.vsend    (HEIGHT + VFP + VS),
@@ -1507,6 +1509,7 @@ emu emu
 	.VGA_SL(scanlines),
 	.VIDEO_ARX(ARX),
 	.VIDEO_ARY(ARY),
+	.HORIZ_INT(horiz_int),
 
 `ifdef USE_FB
 	.FB_EN(fb_en),


### PR DESCRIPTION
Adds option to OSD for automatic horizontal integer scaling. Three settings:

- Off - horizontal scaling as set by aspect ratio, same as current behaviour
- Narrow - rounds scaled horizontal resolution down to nearest integer multiple of core resolution. If this result is lower than core resolution, scales as if integer scaling off.
- Wide - rounds scaled horizontal resolution up to nearest integer multiple of core resolution. If result wider than display resolution, rounds down instead. 

Version incorporated into Genesis core in my fork [here](https://github.com/Yimmers/Genesis_MiSTer), including rbf in releases folder. Further description on mister forums [here](https://misterfpga.org/viewtopic.php?p=18405#p18405).