### PR TITLE
Addition of automatic horizontal scaling to ascal

### DIFF
--- a/mycore.sv
+++ b/mycore.sv
@@ -207,7 +207,7 @@ localparam CONF_STR = {
 	"MyCore;;",
 	"-;",
 	"O89,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
-	"OAB,Intgr Hori Scale,Off,Narrow,Wide;",
+	"OAB,Intgr Hori Scale,Off,Narrow,Wide,Auto;",
 	"O2,TV Mode,NTSC,PAL;",
 	"O34,Noise,White,Red,Green,Blue;",
 	"-;",

--- a/mycore.sv
+++ b/mycore.sv
@@ -38,6 +38,8 @@ module emu
 	//Video aspect ratio for HDMI. Most retro systems have ratio 4:3.
 	output [11:0] VIDEO_ARX,
 	output [11:0] VIDEO_ARY,
+	
+	output [1:0] HORIZ_INT,	// horizontal integer scaling setting
 
 	output  [7:0] VGA_R,
 	output  [7:0] VGA_G,
@@ -197,12 +199,15 @@ wire [1:0] ar = status[9:8];
 
 assign VIDEO_ARX = (!ar) ? 12'd4 : (ar - 1'd1);
 assign VIDEO_ARY = (!ar) ? 12'd3 : 12'd0;
+	
+assign HORIZ_INT = status [11:10];
 
 `include "build_id.v" 
 localparam CONF_STR = {
 	"MyCore;;",
 	"-;",
 	"O89,Aspect ratio,Original,Full Screen,[ARC1],[ARC2];",
+	"OAB,Intgr Hori Scale,Off,Narrow,Wide;",
 	"O2,TV Mode,NTSC,PAL;",
 	"O34,Noise,White,Red,Green,Blue;",
 	"-;",

--- a/sys/ascal.vhd
+++ b/sys/ascal.vhd
@@ -1716,19 +1716,21 @@ BEGIN
       o_hsend  <=hsend; -- <ASYNC> ?
       o_hdisp  <=hdisp; -- <ASYNC> ?
       h_int_multiple := (hmax-hmin+1)/(i_hmax+1);
+      h_int_mod := (hmax - hmin +1) MOD (i_hmax + 1);
+      h_int_up := h_int(1 DOWNTO 0)="10" OR (h_int(1 DOWNTO 0)="11" AND (h_int_mod * 2) > (i_hmax + 1));
 
-      IF h_int(1 DOWNTO 0)="00" OR (h_int_multiple=0 AND h_int(1 DOWNTO 0) = "01") THEN    -- Horizontal integer scaling off
+      IF h_int(1 DOWNTO 0)="00" OR (h_int_multiple=0 AND NOT h_int_up) THEN   -- Horizontal integer scaling off
            o_hmin   <=hmin; -- <ASYNC> ?
            o_hmax   <=hmax; -- <ASYNC> ?
            o_hsize  <=o_hmax - o_hmin + 1;
       ELSE                                                          -- Horizontal integer scaling on
-           IF h_int(1 DOWNTO 0)="01" OR (h_int_multiple+1)*(i_hmax+1) > o_hdisp THEN       -- Narrow (round upscaling multiple down)
+           IF NOT h_int_up OR (h_int_multiple+1)*(i_hmax+1) > o_hdisp THEN    -- Narrow (round upscaling multiple down)
                o_hsize <= h_int_multiple*(i_hmax + 1);
            ELSE                                                     -- Wide (round upscaling multiple up)
-               o_hsize <= (h_int_multiple + 1)*(i_hmax + 1);
+               o_hsize <= (h_int_multiple +1)*(i_hmax + 1);
            END IF;
            o_hmin <= (o_hdisp - o_hsize) / 2;
-           o_hmax <= o_hmin + o_hsize - 1;
+           o_hmax <= o_hmin + o_hsize -1;
       END IF;
 
       o_vtotal <=vtotal; -- <ASYNC> ?

--- a/sys/ascal.vhd
+++ b/sys/ascal.vhd
@@ -1695,6 +1695,8 @@ BEGIN
     VARIABLE dif_v : natural RANGE 0 TO 8*OHRES-1;
     VARIABLE off_v : natural RANGE 0 TO 15;
     VARIABLE h_int_multiple : natural RANGE 0 TO 255;
+    VARIABLE h_int_mod : natural RANGE 0 TO 2047;
+    VARIABLE h_int_up : boolean;
  BEGIN
     IF o_reset_na='0' THEN
       o_copy<=sWAIT;

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -317,6 +317,7 @@ reg  [8:0] coef_data;
 reg        coef_wr = 0;
 
 wire[11:0] ARX, ARY;
+wire[1:0] horiz_int;
 reg [11:0] VSET = 0, HSET = 0;
 reg        FREESCALE = 0;
 reg  [2:0] scaler_flt;
@@ -691,6 +692,7 @@ ascal
 	.hdisp    (WIDTH),
 	.hmin     (hmin),
 	.hmax     (hmax),
+	.h_int	  (horiz_int),
 	.vtotal   (HEIGHT + VFP + VBP + VS),
 	.vsstart  (HEIGHT + VFP),
 	.vsend    (HEIGHT + VFP + VS),
@@ -1507,6 +1509,7 @@ emu emu
 	.VGA_SL(scanlines),
 	.VIDEO_ARX(ARX),
 	.VIDEO_ARY(ARY),
+	.HORIZ_INT(horiz_int),
 
 `ifdef USE_FB
 	.FB_EN(fb_en),


### PR DESCRIPTION
Adds option to OSD for automatic horizontal integer scaling. Four settings:

Off - horizontal scaling as set by aspect ratio, same as current behaviour
Narrow - rounds scaled horizontal resolution down to nearest integer multiple of core resolution. If this result is lower than core resolution, scales as if integer scaling off.
Wide - rounds scaled horizontal resolution up to nearest integer multiple of core resolution. If result wider than display resolution, rounds down instead.
Auto - automatically chooses between narrow and wide, whichever gives closer result to requested aspect ratio.

Version incorporated into Genesis core in my fork [here](https://github.com/Yimmers/Genesis_MiSTer), including rbf in releases folder. Further description on mister forums [here](https://misterfpga.org/viewtopic.php?p=18506#p18506).