### PR TITLE
Add support for CAR and auto width selection for integer scaling

### DIFF
--- a/mycore.sv
+++ b/mycore.sv
@@ -216,7 +216,7 @@ always_comb begin
 			arx = ARC1X;
 			ary = ARC1Y;
 		end
-		2'b11: being //Aspect ratio ARC2
+		2'b11: begin //Aspect ratio ARC2
 			arx = ARC2X;
 			ary = ARC2Y;
 		end

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -1557,6 +1557,11 @@ emu emu
 	.VIDEO_ARX(ARX),
 	.VIDEO_ARY(ARY),
 
+	.ARC1X(arc1x[11:0]),
+	.ARC1Y(arc1y[11:0]),
+	.ARC2X(arc2x[11:0]),
+	.ARC2Y(arc2y[11:0]),
+
 `ifdef USE_FB
 	.FB_EN(fb_en),
 	.FB_FORMAT(fb_fmt),

--- a/sys/video_freak.sv
+++ b/sys/video_freak.sv
@@ -126,7 +126,7 @@ module video_scale_int
 	input  [11:0] arx_i,
 	input  [11:0] ary_i,
 
-	input   [1:0] scale,
+	input   [2:0] scale,
 
 	output reg [12:0] arx_o,
 	output reg [12:0] ary_o,
@@ -228,7 +228,7 @@ always @(posedge CLK_VIDEO) begin
 				end
 
 			8: begin
-					arxf <= {1'b1, !SCALE[2:1] ? w_nonint[11:0] : ((div_res && SCALE[2] || SCALE[0]) && (wideres <= HDMI_WIDTH)) ? wideres : mul_res[11:0]};
+				arxf <= {1'b1, !scale[2:1] ? w_nonint[11:0] : ((div_res && scale[2] || scale[0]) && (wideres <= HDMI_WIDTH)) ? wideres : mul_res[11:0]};
 					aryf <= {1'b1, oheight};
 				end
 		endcase

--- a/sys/video_freak.sv
+++ b/sys/video_freak.sv
@@ -228,7 +228,7 @@ always @(posedge CLK_VIDEO) begin
 				end
 
 			8: begin
-				arxf <= {1'b1, !scale[2:1] ? w_nonint[11:0] : ((div_res && scale[2] || scale[0]) && (wideres <= HDMI_WIDTH)) ? wideres : mul_res[11:0]};
+					arxf <= {1'b1, !scale[2:1] ? w_nonint[11:0] : ((div_res && scale[2] || scale[0]) && (wideres <= HDMI_WIDTH)) ? wideres : mul_res[11:0]};
 					aryf <= {1'b1, oheight};
 				end
 		endcase


### PR DESCRIPTION
These changes allow integer horizontal scaling to take into account aspect ratio setting - either widest possible integer multiple for full screen setting or integer multiple closest to that set by aspect ratio for custom aspect ratio.

Also adds auto setting for horizontal integer scaling - chooses narrow or wide integer scaling based on whichever is closest to selected aspect ratio.

Method described in [this post](https://misterfpga.org/viewtopic.php?p=19507#p19507) on mister forums.

I'm a little uncertain of code in mycore.sv because existing version does not communicate with video_freak. I attempted to add it with cropping disabled.