### PR TITLE
added interpolation to sigma_delta_dac.v

### DIFF
--- a/sys/sigma_delta_dac.v
+++ b/sys/sigma_delta_dac.v
@@ -3,7 +3,7 @@
 //
 // MSBI is the highest bit number. NOT amount of bits!
 //
-module sigma_delta_dac #(parameter MSBI=7, parameter INV=1'b1)
+module sigma_delta_dac #(parameter MSBI=7, parameter INV=1'b1, parameter AMOUNT_OF_STEPS_PER_SAMPLE=24576000/48000)
 (
    output reg      DACout, //Average Output feeding analog lowpass
    input  [MSBI:0] DACin,  //DAC input (excess 2**MSBI)
@@ -16,8 +16,14 @@ reg [MSBI+2:0] SigmaAdder; //Output of Sigma Adder
 reg [MSBI+2:0] SigmaLatch; //Latches output of Sigma Adder
 reg [MSBI+2:0] DeltaB;     //B input of Delta Adder
 
+localparam STEP_RATIO = (1 << 20) / AMOUNT_OF_STEPS_PER_SAMPLE;
+
+shortint step = 0;
+reg [MSBI+2:0] InterpolatedDeltaB;
+
+always @(*) InterpolatedDeltaB = (DeltaB * STEP_RATIO * step) >>> 20;
 always @(*) DeltaB = {SigmaLatch[MSBI+2], SigmaLatch[MSBI+2]} << (MSBI+1);
-always @(*) DeltaAdder = DACin + DeltaB;
+always @(*) DeltaAdder = DACin + InterpolatedDeltaB;
 always @(*) SigmaAdder = DeltaAdder + SigmaLatch;
 
 always @(posedge CLK or posedge RESET) begin
@@ -25,6 +31,7 @@ always @(posedge CLK or posedge RESET) begin
       SigmaLatch <= 1'b1 << (MSBI+1);
       DACout <= INV;
    end else begin
+      step <= step < AMOUNT_OF_STEPS_PER_SAMPLE ? step + 1 : 0;
       SigmaLatch <= SigmaAdder;
       DACout <= SigmaLatch[MSBI+2] ^ INV;
    end


### PR DESCRIPTION
Some people were saying that the analog out has some bitcrusing-like artifacts, just like the mt32-pi has. I was looking into solving the issue in both places. This is a proposed change that might help. I still need to test it myself, but the basic idea is divide the DeltaB into equal steps, as small as we can afford by the clock_freq/sample_rate. This way the transition from one sample to the next should be smoother.
If this is something that you're interested in and makes sense, I'll proceed to test. Maybe you could point me to an example where the problem is easily audible?