### PR TITLE
VGA_EN renamed to VGA_ENB to show signal polarity

### DIFF
--- a/sys/sys_analog.tcl
+++ b/sys/sys_analog.tcl
@@ -40,8 +40,8 @@ set_location_assignment PIN_AH21 -to VGA_B[5]
 set_location_assignment PIN_AH22 -to VGA_HS
 set_location_assignment PIN_AG24 -to VGA_VS
 
-set_location_assignment PIN_AH27 -to VGA_EN
-set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to VGA_EN
+set_location_assignment PIN_AH27 -to VGA_ENB
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to VGA_ENB
 
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_*
 set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to VGA_*

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -72,9 +72,9 @@ module sys_top
 	output  [5:0] VGA_R,
 	output  [5:0] VGA_G,
 	output  [5:0] VGA_B,
-	inout         VGA_HS,  // VGA_HS is secondary SD card detect when VGA_EN = 1 (inactive)
+	inout         VGA_HS,  // VGA_HS is secondary SD card detect when VGA_ENB = 1 (inactive)
 	output		  VGA_VS,
-	input         VGA_EN,  // active low
+	input         VGA_ENB,  // active low
 
 	/////////// AUDIO //////////
 	output		  AUDIO_L,
@@ -139,7 +139,7 @@ wire SD_MISO = mcp_sdcd ? sd_miso : SD_SPI_MISO;
 	assign SDIO_DAT[3]  = SW[3] ? 1'bZ  : SD_CS;
 	assign SDIO_CLK     = SW[3] ? 1'bZ  : SD_CLK;
 	assign SDIO_CMD     = SW[3] ? 1'bZ  : SD_MOSI;
-	assign SD_SPI_CS    = mcp_sdcd ? ((~VGA_EN & sog & ~cs1) ? 1'b1 : 1'bZ) : SD_CS;
+	assign SD_SPI_CS    = mcp_sdcd ? ((~VGA_ENB & sog & ~cs1) ? 1'b1 : 1'bZ) : SD_CS;
 `else
 	assign SD_SPI_CS    = mcp_sdcd ? 1'bZ : SD_CS;
 `endif
@@ -1289,11 +1289,11 @@ csync csync_vga(clk_vid, vga_hs_osd, vga_vs_osd, vga_cs_osd);
 
 	wire cs1 = (vga_fb | vga_scaler) ? vgas_cs : vga_cs;
 
-	assign VGA_VS = (VGA_EN | SW[3]) ? 1'bZ      : ((vga_fb | vga_scaler) ? ~vgas_vs : ~vga_vs) | csync_en;
-	assign VGA_HS = (VGA_EN | SW[3]) ? 1'bZ      :  (vga_fb | vga_scaler) ? (csync_en ? ~vgas_cs : ~vgas_hs) : (csync_en ? ~vga_cs : ~vga_hs);
-	assign VGA_R  = (VGA_EN | SW[3]) ? 6'bZZZZZZ :  (vga_fb | vga_scaler) ? vgas_o[23:18] : vga_o[23:18];
-	assign VGA_G  = (VGA_EN | SW[3]) ? 6'bZZZZZZ :  (vga_fb | vga_scaler) ? vgas_o[15:10] : vga_o[15:10];
-	assign VGA_B  = (VGA_EN | SW[3]) ? 6'bZZZZZZ :  (vga_fb | vga_scaler) ? vgas_o[7:2]   : vga_o[7:2]  ;
+	assign VGA_VS = (VGA_ENB | SW[3]) ? 1'bZ      : ((vga_fb | vga_scaler) ? ~vgas_vs : ~vga_vs) | csync_en;
+	assign VGA_HS = (VGA_ENB | SW[3]) ? 1'bZ      :  (vga_fb | vga_scaler) ? (csync_en ? ~vgas_cs : ~vgas_hs) : (csync_en ? ~vga_cs : ~vga_hs);
+	assign VGA_R  = (VGA_ENB | SW[3]) ? 6'bZZZZZZ :  (vga_fb | vga_scaler) ? vgas_o[23:18] : vga_o[23:18];
+	assign VGA_G  = (VGA_ENB | SW[3]) ? 6'bZZZZZZ :  (vga_fb | vga_scaler) ? vgas_o[15:10] : vga_o[15:10];
+	assign VGA_B  = (VGA_ENB | SW[3]) ? 6'bZZZZZZ :  (vga_fb | vga_scaler) ? vgas_o[7:2]   : vga_o[7:2]  ;
 `endif
 
 reg video_sync = 0;


### PR DESCRIPTION
Using a single letter such a B or N to show active-low signals is a good practice, especially for pins and ports. I suggest renaming VGA_EN to VGA_ENB.