### PR TITLE
Brightness adaptive scanline filters

### DIFF
--- a/sys/hps_io.sv
+++ b/sys/hps_io.sv
@@ -316,7 +316,7 @@ always@(posedge clk_sys) begin : uio_block
 				'h0X17,
 				'h0X18: begin sd_ack <= disk[VD:0]; sdn_ack <= io_din[11:8]; end
 				  'h29: io_dout <= {4'hA, stflg};
-				  'h2B: io_dout <= 1;
+				  'h2B: io_dout <= 2;
 				  'h2F: io_dout <= 1;
 				  'h32: io_dout <= gamma_bus[21];
 				  'h36: begin io_dout <= info_n; info_n <= 0; end

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -295,7 +295,7 @@ reg [31:0] cfg_custom_p2;
 reg  [4:0] vol_att;
 initial vol_att = 5'b11111;
 
-reg  [6:0] coef_addr;
+reg  [12:0] coef_addr;
 reg  [8:0] coef_data;
 reg        coef_wr = 0;
 
@@ -423,7 +423,16 @@ always@(posedge clk_sys) begin
 			if(cmd == 'h25) {led_overtake, led_state} <= io_din;
 			if(cmd == 'h26) vol_att <= io_din[4:0];
 			if(cmd == 'h27) VSET <= io_din[11:0];
-			if(cmd == 'h2A) {coef_wr,coef_addr,coef_data} <= {1'b1,io_din};
+			if(cmd == 'h2A) begin
+				if (cnt == 0) begin
+					coef_addr <= io_din[12:0] - 1'd1;
+					cnt <= 1'd1;
+				end else begin
+					coef_wr <= 1'd1;
+					coef_data <= io_din[8:0];
+					coef_addr <= coef_addr + 1'd1;
+				end
+			end
 			if(cmd == 'h2B) scaler_flt <= io_din[2:0];
 			if(cmd == 'h37) {FREESCALE,HSET} <= {io_din[15],io_din[11:0]};
 			if(cmd == 'h38) vs_line <= io_din[11:0];


### PR DESCRIPTION
Interpolate between two sets of filter coefficients based on the luminosity of the source pixel, allowing an effect similar to hybrid scanlines or intensity modulation from the retrotink scalers. 

This is based on an algorithm suggested by @ghogan42.

Main uploads two sets of phase coefficients, the phase coefficients used are calculated by interpolating between those two sets. I initially used DSP for the interpolation, but not it is done with regular logic. Main uploads the sets as a "origin" set and a "delta" set so the interpolation can be calculated as `A + ((B-A)*t)`.

Resource usage is 2 block ram units to store the second set of coefficients and ~400ALM for the interpolation logic.

Depends on https://github.com/wickerwaka/Main_MiSTer/commit/2cb9bc8d12f6a486646cfc4366156845d014c07d
