### PR TITLE
Pass rotation flag to main

### DIFF
--- a/mycore.sv
+++ b/mycore.sv
@@ -26,7 +26,7 @@ module emu
 	input         RESET,
 
 	//Must be passed to hps_io module
-	inout  [48:0] HPS_BUS,
+	inout  [49:0] HPS_BUS,
 
 	//Base video clock. Usually equals to CLK_SYS.
 	output        CLK_VIDEO,
@@ -39,6 +39,7 @@ module emu
 	//if VIDEO_ARX[12] or VIDEO_ARY[12] is set then [11:0] contains scaled size instead of aspect ratio.
 	output [12:0] VIDEO_ARX,
 	output [12:0] VIDEO_ARY,
+	output        VIDEO_ROTATED,
 
 	output  [7:0] VGA_R,
 	output  [7:0] VGA_G,
@@ -183,6 +184,8 @@ assign VGA_SL = 0;
 assign VGA_F1 = 0;
 assign VGA_SCALER = 0;
 assign HDMI_FREEZE = 0;
+
+assign VIDEO_ROTATED = 0;
 
 assign AUDIO_S = 0;
 assign AUDIO_L = 0;

--- a/sys/arcade_video.v
+++ b/sys/arcade_video.v
@@ -176,6 +176,8 @@ module screen_rotate
 	input         no_rotate,
 	input         flip,
 
+	output reg    VIDEO_ROTATED,
+
 	output            FB_EN,
 	output      [4:0] FB_FORMAT,
 	output reg [11:0] FB_WIDTH,
@@ -222,6 +224,7 @@ function [1:0] buf_next;
 endfunction
 
 always @(posedge CLK_VIDEO) begin
+	VIDEO_ROTATED <= ~no_rotate;
 	do_flip <= no_rotate && flip;
 	if( do_flip ) begin
 		FB_WIDTH  <= hsz;

--- a/sys/hps_io.sv
+++ b/sys/hps_io.sv
@@ -30,7 +30,7 @@
 module hps_io #(parameter CONF_STR, CONF_STR_BRAM=1, PS2DIV=0, WIDE=0, VDNUM=1, BLKSZ=2, PS2WE=0)
 (
 	input             clk_sys,
-	inout      [48:0] HPS_BUS,
+	inout      [49:0] HPS_BUS,
 
 	// buttons up to 32
 	output reg [31:0] joystick_0,
@@ -216,6 +216,7 @@ video_calc video_calc
 	.vs_hdmi(HPS_BUS[44]),
 	.f1(HPS_BUS[45]),
 	.new_vmode(new_vmode),
+	.rotated(HPS_BUS[49]),
 
 	.par_num(byte_cnt[3:0]),
 	.dout(vc_dout)
@@ -847,6 +848,7 @@ module video_calc
 	input vs_hdmi,
 	input f1,
 	input new_vmode,
+	input rotated,
 
 	input       [3:0] par_num,
 	output reg [15:0] dout
@@ -854,7 +856,7 @@ module video_calc
 
 always @(posedge clk_sys) begin
 	case(par_num)
-		1: dout <= {|vid_int, vid_nres};
+		1: dout <= {vid_rotated, |vid_int, vid_nres};
 		2: dout <= vid_hcnt[15:0];
 		3: dout <= vid_hcnt[31:16];
 		4: dout <= vid_vcnt[15:0];
@@ -875,6 +877,7 @@ reg [31:0] vid_hcnt = 0;
 reg [31:0] vid_vcnt = 0;
 reg  [7:0] vid_nres = 0;
 reg  [1:0] vid_int  = 0;
+reg        vid_rotated = 0;
 
 always @(posedge clk_vid) begin
 	integer hcnt;
@@ -893,6 +896,7 @@ always @(posedge clk_vid) begin
 
 		if(old_vs & ~vs) begin
 			vid_int <= {vid_int[0],f1};
+			vid_rotated <= rotated;
 			if(~f1) begin
 				if(hcnt && vcnt) begin
 					old_vmode <= new_vmode;

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -1459,6 +1459,7 @@ wire [15:0] audio_l, audio_r;
 wire        audio_s;
 wire  [1:0] audio_mix;
 wire  [1:0] scanlines;
+wire        video_rotated;
 wire  [7:0] r_out, g_out, b_out, hr_out, hg_out, hb_out;
 wire        vs_fix, hs_fix, de_emu, vs_emu, hs_emu, f1;
 wire        hvs_fix, hhs_fix, hde_emu;
@@ -1538,7 +1539,7 @@ emu emu
 (
 	.CLK_50M(FPGA_CLK2_50),
 	.RESET(reset),
-	.HPS_BUS({fb_en, sl, f1, HDMI_TX_VS, 
+	.HPS_BUS({video_rotated, fb_en, sl, f1, HDMI_TX_VS, 
 				 clk_100m, clk_ihdmi,
 				 ce_hpix, hde_emu, hhs_fix, hvs_fix, 
 				 io_wait, clk_sys, io_fpga, io_uio, io_strobe, io_wide, io_din, io_dout}),
@@ -1561,6 +1562,7 @@ emu emu
 	.VGA_SL(scanlines),
 	.VIDEO_ARX(ARX),
 	.VIDEO_ARY(ARY),
+	.VIDEO_ROTATED(video_rotated),
 
 `ifdef MISTER_FB
 	.FB_EN(fb_en),


### PR DESCRIPTION
Add a `VIDEO_ROTATED` output port to the `emu` module. Defaults to `0` in the template but can be set with the `screen_rotate` module. `VIDEO_ROTATED` indicates whether we are simulating a rotate display or not. The flag is passed through the `HPS_BUS` into the `video_calc` module which provides the value to main.

This does add an additional port to emu so all cores will require a little tweaking when they update sys, not sure if there is any way to avoid that other than using a macro/define that arcade cores could enable.

https://github.com/MiSTer-devel/Main_MiSTer/pull/543 contains the main-side changes.
