### PR TITLE
Support 256 phases in upscaler

### DIFF
--- a/sys/hps_io.sv
+++ b/sys/hps_io.sv
@@ -320,9 +320,9 @@ always@(posedge clk_sys) begin : uio_block
 				'h0X18: begin sd_ack <= disk[VD:0]; sdn_ack <= io_din[11:8]; end
 				  'h29: io_dout <= {4'hA, stflg};
 `ifdef MISTER_DISABLE_ADAPTIVE
-				  'h2B: io_dout <= {HPS_BUS[48:46],4'b0010};
+				  'h2B: io_dout <= {HPS_BUS[48:46],4'b0110};
 `else
-				  'h2B: io_dout <= {HPS_BUS[48:46],4'b0011};
+				  'h2B: io_dout <= {HPS_BUS[48:46],4'b0111};
 `endif
 				  'h2F: io_dout <= 1;
 				  'h32: io_dout <= gamma_bus[21];

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -295,7 +295,7 @@ reg [31:0] cfg_custom_p2;
 reg  [4:0] vol_att;
 initial vol_att = 5'b11111;
 
-reg  [9:0] coef_addr;
+reg  [11:0] coef_addr;
 reg  [8:0] coef_data;
 reg        coef_wr = 0;
 
@@ -424,7 +424,7 @@ always@(posedge clk_sys) begin
 			if(cmd == 'h27) VSET <= io_din[11:0];
 			if(cmd == 'h2A) begin
 				if(cnt[0]) {coef_wr,coef_data} <= {1'b1,io_din[8:0]};
-				else coef_addr <= io_din[9:0];
+				else coef_addr <= io_din[11:0];
 			end
 			if(cmd == 'h2B) scaler_flt <= io_din[2:0];
 			if(cmd == 'h37) {FREESCALE,HSET} <= {io_din[15],io_din[11:0]};
@@ -647,7 +647,7 @@ ascal
 `ifdef MISTER_DOWNSCALE_NN
 	.DOWNSCALE_NN("true"),
 `endif
-	.FRAC(6),
+	.FRAC(8),
 	.N_DW(128),
 	.N_AW(28)
 )


### PR DESCRIPTION
Set FRAC to 8.
Add an additional stage in the horizontal upscale and increase division by 2 bits.
Add yet another version to the filter version we send back.

No changes to blockram or DSP usage. ALM usage varies by core.

Genesis: -111 (???)
SNES: -99 (???)
NeoGeo: +150


[Basic_Scanlines_256_Phases.zip](https://github.com/MiSTer-devel/Template_MiSTer/files/8103392/Basic_Scanlines_256_Phases.zip)
![64vs256_horizontal](https://user-images.githubusercontent.com/6377250/154827656-bfca7a60-24b3-4b3e-bba8-6bea1cf3614b.png)
![64vs256_vertical](https://user-images.githubusercontent.com/6377250/154827657-56d403ae-364a-4976-945b-13dc2449ae5a.png)

