### PR TITLE
Increase polyphase coefficient size to 10-bits

### DIFF
--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -296,7 +296,7 @@ reg  [4:0] vol_att;
 initial vol_att = 5'b11111;
 
 reg  [11:0] coef_addr;
-reg  [8:0] coef_data;
+reg  [9:0] coef_data;
 reg        coef_wr = 0;
 
 wire[12:0] ARX, ARY;
@@ -423,7 +423,7 @@ always@(posedge clk_sys) begin
 			if(cmd == 'h26) vol_att <= io_din[4:0];
 			if(cmd == 'h27) VSET <= io_din[11:0];
 			if(cmd == 'h2A) begin
-				if(cnt[0]) {coef_wr,coef_data} <= {1'b1,io_din[8:0]};
+				if(cnt[0]) {coef_wr,coef_data} <= {1'b1,io_din[9:0]};
 				else coef_addr <= io_din[11:0];
 			end
 			if(cmd == 'h2B) scaler_flt <= io_din[2:0];


### PR DESCRIPTION
There is very little cost to this, just a few extra bits in some registers. 256 phases, with 4 10-bit coefficients fits exactly into an M10K block ram. Not sure if the extra precision will have any noticeable benefit to upscaling quality, but might as well use as much as we can.

Deleted the init function since they weren't doing anything with >=64 phases anyway.