### PR TITLE
HDMI Pixel Repeat

### DIFF
--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -365,6 +365,7 @@ always@(posedge clk_sys) begin
 				acy2 <= -24'd2023767;
 				areset <= 1;
 			end
+			if(io_din[7:0] == 'h20) io_dout_sys <= 1;
 `ifndef MISTER_DEBUG_NOHDMI
 			if(io_din[7:0] == 'h40) io_dout_sys <= fb_crc;
 `endif
@@ -380,14 +381,14 @@ always@(posedge clk_sys) begin
 				cfg_set <= 0;
 				if(cnt<8) begin
 					case(cnt[2:0])
-						0: WIDTH      <= io_din[11:0];
-						1: HFP        <= io_din[11:0];
-						2: HS         <= {io_din[15], io_din[11:0]};
-						3: HBP        <= io_din[11:0];
-						4: HEIGHT     <= io_din[11:0];
-						5: VFP        <= io_din[11:0];
-						6: VS         <= {io_din[15],io_din[11:0]};
-						7: VBP        <= io_din[11:0];
+						0: {HDMI_PR,WIDTH} <= {io_din[15], io_din[11:0]};
+						1: HFP             <= io_din[11:0];
+						2: HS              <= {io_din[15], io_din[11:0]};
+						3: HBP             <= io_din[11:0];
+						4: HEIGHT          <= io_din[11:0];
+						5: VFP             <= io_din[11:0];
+						6: VS              <= {io_din[15],io_din[11:0]};
+						7: VBP             <= io_din[11:0];
 					endcase
 `ifndef MISTER_DEBUG_NOHDMI
 					if(cnt == 1) begin
@@ -843,7 +844,7 @@ always @(posedge clk_vid) begin
 	reg  [2:0] state;
 
 	hdmi_height <= (VSET && (VSET < HEIGHT)) ? VSET : HEIGHT;
-	hdmi_width  <= (HSET && (HSET < WIDTH))  ? HSET : WIDTH;
+	hdmi_width  <= (HSET && (HSET < WIDTH))  ? HSET << HDMI_PR : WIDTH << HDMI_PR;
 
 	if(!ARY) begin
 		if(ARX == 1) begin
@@ -912,7 +913,7 @@ always @(posedge clk_vid) begin
 			end
 
 		6: begin
-				videow <= (wcalc > hdmi_width)  ? hdmi_width  : wcalc[11:0];
+				videow <= (wcalc > hdmi_width)  ? (hdmi_width >> HDMI_PR)  : (wcalc[11:0] >> HDMI_PR);
 				videoh <= (hcalc > hdmi_height) ? hdmi_height : hcalc[11:0];
 			end
 
@@ -986,14 +987,15 @@ pll_hdmi pll_hdmi
 `endif
 
 //1920x1080@60 PCLK=148.5MHz CEA
-reg  [11:0] WIDTH  = 1920;
-reg  [11:0] HFP    = 88;
-reg  [12:0] HS     = 48;
-reg  [11:0] HBP    = 148;
-reg  [11:0] HEIGHT = 1080;
-reg  [11:0] VFP    = 4;
-reg  [12:0] VS     = 5;
-reg  [11:0] VBP    = 36;
+reg  [11:0] WIDTH   = 1920;
+reg  [11:0] HFP     = 88;
+reg  [12:0] HS      = 48;
+reg  [11:0] HBP     = 148;
+reg  [11:0] HEIGHT  = 1080;
+reg  [11:0] VFP     = 4;
+reg  [12:0] VS      = 5;
+reg  [11:0] VBP     = 36;
+reg         HDMI_PR = 0;
 
 wire [63:0] reconfig_to_pll;
 wire [63:0] reconfig_from_pll;


### PR DESCRIPTION
Add support for hdmi pixel repetition in aspect ratio calcs.
Pixel repetition is indicated by the high bit of the video mode width.
Return 1 from setvideo command so main can detect support for pixel repetition.