### PR TITLE
Use half size when height matches vertical resolution.

### DIFF
--- a/sys/osd.v
+++ b/sys/osd.v
@@ -131,7 +131,7 @@ wire [21:0] osd_h_hdr = (info || rot) ? osd_h : (osd_h + OSD_HDR);
 
 // pipeline the comparisons a bit
 always @(posedge clk_video) if(ce_pix) begin
-	v_cnt_h <= v_cnt < osd_t;
+	v_cnt_h <= v_cnt <= osd_t;
 	v_cnt_1 <= v_cnt < 320;
 	v_cnt_2 <= v_cnt < 640;
 	v_cnt_3 <= v_cnt < 960;


### PR DESCRIPTION
If the height exactly matches the vertical resolution then v_osd_start will be set to 0, but v_cnt starts counting from 1 so the OSD will never be drawn. Maybe v_cnt should start at 0, but that will throw of some other things. This fixes the issue I am seeing in the M72 core which has a vertical resolution of 256.