### PR TITLE
Add a macro to enable 4K horizontal resolution

### DIFF
--- a/mycore.qsf
+++ b/mycore.qsf
@@ -73,6 +73,9 @@ set_global_assignment -name SEED 1
 # Disable ALSA audio output to save some resources
 #set_global_assignment -name VERILOG_MACRO "MISTER_DISABLE_ALSA=1"
 
+# Increase maximum horizontal output resolution from 2048 to 4096--may exceed resource limits
+#set_global_assignment -name VERILOG_MACRO "MISTER_4K_HORIZONTAL_RES=1"
+
 source sys/sys.tcl
 source sys/sys_analog.tcl
 source files.qip

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -686,6 +686,9 @@ ascal
 `ifdef MISTER_DOWNSCALE_NN
 	.DOWNSCALE_NN("true"),
 `endif
+`ifdef MISTER_4K_HORIZONTAL_RES
+	.OHRES(4096),
+`endif
 	.FRAC(8),
 	.N_DW(128),
 	.N_AW(28)


### PR DESCRIPTION
The main use case for this is described in my forum post [here](https://misterfpga.org/viewtopic.php?f=29&t=7357). Short version: 3840x720 MiSTer output resolution scaled to 3840x2160 on a 4K display (with custom aspect ratio to compensate for the streteching) allows full use of the display's horizontal resolution for filters/shadow masks/integer scaling.

Additionally, this would be useful for anyone wanting to play the GBA core on a 1440p monitor--to get the largest possible image without display scaling, you'd need an output resolution of 2160x1440. This is currently only possible with pixel repetition, but PR is a poor fit here because 2160 is an odd multiple (9x) of 240, so you'd get alternating 8x and 10x pixels.

The only major issue I've encountered compiling and testing cores with the increased resolution limit is not having enough block RAM to compile SNES, TurboGrafx, and Saturn. Other cores I compiled include:

- Atari7800
- Gameboy
- GBA
- MegaCD
- MegaDrive (didn't meet timing requirements--setup slack is -4 compared with -2.5 without, no issues in testing)
- Minimig
- MSX
- N64
- NES
- NeoGeo
- PSX
- S32X
- SMS
- all Jotego cores

Thanks to Newsdee on the forums for the idea of implementing this as a macro.
