### PR TITLE
Add 18-bit to 24-bit PWM option for native VGA output

### DIFF
--- a/sys/sys.qip
+++ b/sys/sys.qip
@@ -16,6 +16,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) v
 set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) arcade_video.v ]
 set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) osd.v ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) vga_out.sv ]
+set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) vga_pwm.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) yc_out.sv ]
 set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) i2c.v ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) alsa.sv ]

--- a/sys/sys_analog.tcl
+++ b/sys/sys_analog.tcl
@@ -46,6 +46,12 @@ set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to VGA_EN
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to VGA_*
 set_instance_assignment -name CURRENT_STRENGTH_NEW 8MA -to VGA_*
 
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to VGA_R[*]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to VGA_G[*]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to VGA_B[*]
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to VGA_HS
+set_instance_assignment -name FAST_OUTPUT_REGISTER ON -to VGA_VS
+
 #============================================================
 # AUDIO
 #============================================================

--- a/sys/vga_pwm.sv
+++ b/sys/vga_pwm.sv
@@ -1,0 +1,39 @@
+
+module vga_pwm
+(
+	input         clk,
+	input         csync_en,
+
+	input         hsync,
+	input         csync,
+
+	input  	  [23:0] din,
+	output reg [23:0] dout
+);
+
+reg [1:0]  vga_pwm;
+always @(posedge clk) begin
+
+	if (csync_en ? ~csync : ~hsync)
+		vga_pwm <= vga_pwm + 1'd1; 
+	else
+		vga_pwm <= 2'd3;
+	
+	if (vga_pwm < din[17:16] && din[23:18] < 6'b111111)
+		dout[23:18] <= din[23:18] + 1'd1;
+	else 	
+		dout[23:18] <= din[23:18];
+		
+	if (vga_pwm < din[9:8] && din[15:10] < 6'b111111)
+		dout[15:10] <= din[15:10] + 1'd1;
+	else 	
+		dout[15:10] <= din[15:10];
+		
+	if (vga_pwm < din[1:0] && din[7:2] < 6'b111111)
+		dout[7:2] <= din[7:2] + 1'd1;
+	else 	
+		dout[7:2] <= din[7:2];
+
+end
+
+endmodule


### PR DESCRIPTION
The Analog I/O board has an 18-bit output limitation on the VGA port. Using this PWM method the output can quickly switch between two near 6-bit values to get a color in between. The pulse width of these values is determined by the 2 unused bits of the 8-bit values.
This is possible because many cores use a video clock which is 4x that of the pixel clock, so color values can be switched multiple times per pixel. You could also look at this as increasing the horizontal resolution and dithering horizontally.

This technique also seems to improve s-video and component signals. We have been testing it in the Mister discord and it work well on CRT, LCD and upscalers with no significant downsides found yet. Here is a thread I made on the Mister forums with some examples:

https://misterfpga.org/viewtopic.php?t=7565

Some limitations are that it won't work on the scaler output since the HDMI clock seems to be the same as the pixel clock. Also some cores may not have a video clock that is fast enough for this so PWM should be enabled on a per core basis by defining 'MISTER_ENABLE_PWM'. But so far it works well for N64, PSX, Saturn and the Groovy core, which are probably the cores that benefit most from this.
The VGA port pins are set as output registers to reduce major-carry transition glitches which happen a lot with this PWM technique. Without this the glitches caused slight color skews.
 
I am new to FPGA programming but I wanted to make these changes because the 18-bit limitations were very noticeable to me on the new N64 core. But please let me know if I am doing anything wrong here.