### PR TITLE
Better verilog standard compliance

### DIFF
--- a/sys/arcade_video.v
+++ b/sys/arcade_video.v
@@ -61,7 +61,7 @@ sync_fix sync_h(CLK_VIDEO, VSync, vs_fix);
 reg [DW-1:0] RGB_fix;
 
 reg CE,HS,VS,HBL,VBL;
-always @(posedge CLK_VIDEO) begin
+always @(posedge CLK_VIDEO) begin : hbl_block
 	reg old_ce;
 	old_ce <= ce_pix;
 	CE <= 0;
@@ -236,7 +236,7 @@ always @(posedge CLK_VIDEO) begin
 end
 
 reg [1:0] i_fb,o_fb;
-always @(posedge CLK_VIDEO) begin
+always @(posedge CLK_VIDEO) begin : old_block
 	reg old_vbl,old_vs;
 	old_vbl <= FB_VBL;
 	old_vs <= VGA_VS;
@@ -259,7 +259,7 @@ reg  [2:0] fb_en = 0;
 reg [11:0] hsz = 320, vsz = 240;
 reg [11:0] bwidth;
 reg [22:0] bufsize;
-always @(posedge CLK_VIDEO) begin
+always @(posedge CLK_VIDEO) begin : old_vs_block
 	reg [11:0] hcnt = 0, vcnt = 0;
 	reg old_vs, old_de;
 
@@ -291,7 +291,7 @@ wire [13:0] stride = {bwidth[11:2], 4'd0};
 reg [22:0] ram_addr, next_addr;
 reg [31:0] ram_data;
 reg        ram_wr;
-always @(posedge CLK_VIDEO) begin
+always @(posedge CLK_VIDEO) begin : vga_de_block
 	reg [13:0] hcnt = 0;
 	reg old_vs, old_de;
 

--- a/sys/audio_out.v
+++ b/sys/audio_out.v
@@ -51,7 +51,7 @@ localparam FILTER_DIV = (CE_RATE/(AUDIO_RATE*32))-1;
 wire [31:0] real_ce = sample_rate ? {CE_RATE[30:0],1'b0} : CE_RATE[31:0];
 
 reg mclk_ce;
-always @(posedge clk) begin
+always @(posedge clk) begin : mclk_block
 	reg [31:0] cnt;
 
 	mclk_ce = 0;
@@ -63,7 +63,7 @@ always @(posedge clk) begin
 end
 
 reg i2s_ce;
-always @(posedge clk) begin
+always @(posedge clk) begin : i2s_block
 	reg div;
 	i2s_ce <= 0;
 	if(mclk_ce) begin
@@ -115,7 +115,7 @@ sigma_delta_dac #(15) sd_r
 );
 
 reg sample_ce;
-always @(posedge clk) begin
+always @(posedge clk) begin : sample_block
 	reg [8:0] div = 0;
 	reg [1:0] add = 0;
 
@@ -129,7 +129,7 @@ always @(posedge clk) begin
 end
 
 reg flt_ce;
-always @(posedge clk) begin
+always @(posedge clk) begin : filter_block
 	reg [31:0] cnt = 0;
 
 	flt_ce = 0;
@@ -141,7 +141,7 @@ always @(posedge clk) begin
 end
 
 reg [15:0] cl,cr;
-always @(posedge clk) begin
+always @(posedge clk) begin : cl_block
 	reg [15:0] cl1,cl2;
 	reg [15:0] cr1,cr2;
 
@@ -153,7 +153,7 @@ always @(posedge clk) begin
 end
 
 reg a_en1 = 0, a_en2 = 0;
-always @(posedge clk, posedge reset) begin
+always @(posedge clk, posedge reset) begin : dly_block
 	reg  [1:0] dly1 = 0;
 	reg [14:0] dly2 = 0;
 

--- a/sys/ddr_svc.sv
+++ b/sys/ddr_svc.sv
@@ -34,7 +34,7 @@ module ddr_svc
 	output  [7:0] ram_byteenable,
 	output reg    ram_write,
 
-	output  [7:0] ram_bcnt,
+	output reg [7:0] ram_bcnt,
 
 	input  [31:3] ch0_addr,
 	input   [7:0] ch0_burst,

--- a/sys/hq2x.sv
+++ b/sys/hq2x.sv
@@ -297,16 +297,16 @@ endmodule
 
 module Blend
 (
-	input         clk,
-	input         clk_en,
-	input   [5:0] rule,
-	input  [23:0] E,
-	input  [23:0] A,
-	input  [23:0] B,
-	input  [23:0] D,
-	input  [23:0] F,
-	input  [23:0] H,
-	output [23:0] Result
+	input             clk,
+	input             clk_en,
+	input       [5:0] rule,
+	input      [23:0] E,
+	input      [23:0] A,
+	input      [23:0] B,
+	input      [23:0] D,
+	input      [23:0] F,
+	input      [23:0] H,
+	output reg [23:0] Result
 );
 
 	localparam BLEND1 = 7'b110_10_00; // (A * 12 + B * 4        ) >> 4

--- a/sys/i2c.v
+++ b/sys/i2c.v
@@ -56,7 +56,7 @@ end
 
 assign I2C_RDATA = rdata;
 
-always @(posedge CLK) begin
+always @(posedge CLK) begin : i2c_core_block
 	reg old_clk;
 	reg old_st;
 	reg rd,len;

--- a/sys/i2s.v
+++ b/sys/i2s.v
@@ -16,7 +16,7 @@ module i2s
 	input [AUDIO_DW-1:0]	right_chan
 );
 
-always @(posedge clk) begin
+always @(posedge clk) begin : i2s_audio_block
 	reg  [7:0] bit_cnt;
 	reg msclk;
 

--- a/sys/iir_filter.v
+++ b/sys/iir_filter.v
@@ -175,7 +175,7 @@ begin
 end
 endfunction
 
-(* ramstyle = "logic" *) reg [39:0] intreg[2];
+(* ramstyle = "logic" *) reg [39:0] intreg[1:0];
 always @(posedge clk, posedge reset) begin
 	if(reset) {intreg[0],intreg[1]} <= 80'd0;
 	else if(ce) intreg[ch] <= x_mul(x) - y_mul[60:21] + z;

--- a/sys/osd.v
+++ b/sys/osd.v
@@ -46,7 +46,7 @@ reg [21:0] osd_w;
 
 reg  [1:0] rot = 0;
 
-always@(posedge clk_sys) begin
+always@(posedge clk_sys) begin : bcnt_block
 	reg [12:0] bcnt;
 	reg  [7:0] cmd;
 	reg        has_cmd;
@@ -100,7 +100,7 @@ always@(posedge clk_sys) begin
 end
 
 (* direct_enable *) reg ce_pix;
-always @(posedge clk_video) begin
+always @(posedge clk_video) begin : pix_block
 	reg [21:0] cnt = 0;
 	reg [21:0] pixsz, pixcnt;
 	reg deD;
@@ -152,7 +152,7 @@ always @(posedge clk_video) if(ce_pix) begin
 	v_info_start_5 <= rot[0] ? (infox + (infox << 2)) : (infoy + (infoy << 2));
 end
 
-always @(posedge clk_video) begin
+always @(posedge clk_video) begin : osd_block
 	reg        deD;
 	reg  [2:0] osd_div;
 	reg  [2:0] multiscan;
@@ -257,7 +257,7 @@ end
 reg [23:0] rdout;
 assign dout = rdout;
 
-always @(posedge clk_video) begin
+always @(posedge clk_video) begin : out_block
 	reg [23:0] ordout1, nrdout1, rdout2, rdout3;
 	reg de1,de2,de3;
 	reg osd_mux;

--- a/sys/scandoubler.v
+++ b/sys/scandoubler.v
@@ -19,7 +19,7 @@
 
 // TODO: Delay vsync one line
 
-module scandoubler #(parameter LENGTH, parameter HALF_DEPTH)
+module scandoubler #(parameter LENGTH=768, parameter HALF_DEPTH=0)
 (
 	// system interface
 	input             clk_vid,
@@ -56,7 +56,7 @@ wire [7:0] pc_in = pix_in_cnt + 1'b1;
 reg  [7:0] pixsz, pixsz2, pixsz4 = 0;
 
 reg ce_x4i, ce_x1i;
-always @(posedge clk_vid) begin
+always @(posedge clk_vid) begin : old_ce_block
 	reg old_ce, valid, hs;
 
 	if(~&pix_len) pix_len <= pl;
@@ -120,7 +120,7 @@ reg  [7:0] pix_out_cnt = 0;
 wire [7:0] pc_out = pix_out_cnt + 1'b1;
 
 reg ce_x4o, ce_x2o;
-always @(posedge clk_vid) begin
+always @(posedge clk_vid) begin : pix_out_cnt_block
 	reg hs;
 
 	if(~&pix_out_cnt) pix_out_cnt <= pc_out;
@@ -144,7 +144,7 @@ reg [1:0] sd_line;
 reg [3:0] vbo;
 reg [3:0] vso;
 reg [8:0] hbo;
-always @(posedge clk_vid) begin
+always @(posedge clk_vid) begin : sync_block
 
 	reg [31:0] hcnt;
 	reg [30:0] sd_hcnt;

--- a/sys/scanlines.v
+++ b/sys/scanlines.v
@@ -13,7 +13,7 @@ module scanlines #(parameter v2=0)
 );
 
 reg [1:0] scanline;
-always @(posedge clk) begin
+always @(posedge clk) begin : scanline_block
 	reg old_hs, old_vs;
 
 	old_hs <= hs_in;
@@ -54,7 +54,7 @@ always @(*) begin
 	endcase
 end
 
-always @(posedge clk) begin
+always @(posedge clk) begin : vga_out_block
 	reg [23:0] dout1, dout2;
 	reg de1,de2,vs1,vs2,hs1,hs2,ce1,ce2;
 

--- a/sys/sys_top.sdc
+++ b/sys/sys_top.sdc
@@ -33,9 +33,9 @@ set_false_path -from {get_ports {SW[*]}}
 set_false_path -to   {cfg[*]}
 set_false_path -from {cfg[*]}
 set_false_path -from {VSET[*]}
-set_false_path -to   {wcalc[*] hcalc[*]}
+set_false_path -to   {video_calc_block.wcalc[*] video_calc_block.hcalc[*]}
 set_false_path -to   {hdmi_width[*] hdmi_height[*]}
-set_false_path -to   {deb_* btn_en btn_up}
+set_false_path -to   {user_button_block.deb_* btn_en btn_up}
 
 set_multicycle_path -to {*_osd|osd_vcnt*} -setup 2
 set_multicycle_path -to {*_osd|osd_vcnt*} -hold 1
@@ -48,8 +48,8 @@ set_false_path -from {*_osd|v_osd_start*}
 set_false_path -from {*_osd|v_info_start*}
 set_false_path -from {*_osd|h_osd_start*}
 set_false_path -from {*_osd|rot*}
-set_false_path -from {*_osd|dsp_width*}
-set_false_path -to   {*_osd|half}
+set_false_path -from {*_osd|osd_block.dsp_width*}
+set_false_path -to   {*_osd|osd_block.half}
 
 set_false_path -to   {WIDTH[*] HFP[*] HS[*] HBP[*] HEIGHT[*] VFP[*] VS[*] VBP[*]}
 set_false_path -from {WIDTH[*] HFP[*] HS[*] HBP[*] HEIGHT[*] VFP[*] VS[*] VBP[*]}

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -206,7 +206,7 @@ wire btn_o = (mcp_en | SW[3]) ? mcp_btn[2] : (BTN_EN & ~BTN_OSD  );
 wire btn_u = (mcp_en | SW[3]) ? mcp_btn[0] : (BTN_EN & ~BTN_USER );
 
 reg btn_user, btn_osd;
-always @(posedge FPGA_CLK2_50) begin
+always @(posedge FPGA_CLK2_50) begin : user_button_block
 	integer div;
 	reg [7:0] deb_user;
 	reg [7:0] deb_osd;
@@ -346,7 +346,7 @@ reg [12:0] arc2x = 0;
 reg [12:0] arc2y = 0;
 reg [15:0] io_dout_sys;
 
-always@(posedge clk_sys) begin
+always@(posedge clk_sys) begin : cmd_block
 	reg  [7:0] cmd;
 	reg        has_cmd;
 	reg  [7:0] cnt = 0;
@@ -864,7 +864,7 @@ reg [11:0] arx;
 reg [11:0] ary;
 reg        arxy;
 
-always @(posedge clk_vid) begin
+always @(posedge clk_vid) begin : video_calc_block
 	reg [11:0] hmini,hmaxi,vmini,vmaxi;
 	reg [11:0] wcalc,videow;
 	reg [11:0] hcalc,videoh;
@@ -988,7 +988,7 @@ wire        pal_wr;
 
 reg  [28:0] pal_addr;
 reg         pal_req = 0;
-always @(posedge clk_pal) begin
+always @(posedge clk_pal) begin : vs_block
 	reg old_vs1, old_vs2;
 
 	pal_addr <= LFB_BASE[31:3] - 29'd512;
@@ -1173,7 +1173,7 @@ reg        dv_hs, dv_vs, dv_de;
 wire [23:0] dv_data_osd;
 wire dv_hs_osd, dv_vs_osd, dv_cs_osd;
 
-always @(posedge clk_vid) begin
+always @(posedge clk_vid) begin : dv_block
 	reg [23:0] dv_d1, dv_d2;
 	reg        dv_de1, dv_de2, dv_hs1, dv_hs2, dv_vs1, dv_vs2;
 	reg [12:0] vsz, vcnt, vcnt_l, vcnt_ll;
@@ -1265,7 +1265,7 @@ reg hdmi_out_vs;
 reg hdmi_out_de;
 reg [23:0] hdmi_out_d;
 
-always @(posedge hdmi_tx_clk) begin
+always @(posedge hdmi_tx_clk) begin : hdmi_out_block
 	reg [23:0] hdmi_dv_data;
 	reg        hdmi_dv_hs, hdmi_dv_vs, hdmi_dv_de;
 
@@ -1456,7 +1456,7 @@ csync csync_vga(clk_vid, vga_hs_osd, vga_vs_osd, vga_cs_osd);
 `endif
 
 reg video_sync = 0;
-always @(posedge clk_vid) begin
+always @(posedge clk_vid) begin : line_block
 	reg [11:0] line_cnt  = 0;
 	reg [11:0] sync_line = 0;
 	reg  [1:0] hs_cnt = 0;
@@ -1817,7 +1817,7 @@ module sync_fix
 assign sync_out = sync_in ^ pol;
 
 reg pol;
-always @(posedge clk) begin
+always @(posedge clk) begin : pol_block
 	reg [31:0] cnt;
 	reg s1,s2;
 
@@ -1850,7 +1850,7 @@ module csync
 assign csync = (csync_vs ^ csync_hs);
 
 reg csync_hs, csync_vs;
-always @(posedge clk) begin
+always @(posedge clk) begin : h_cnt_block
 	reg prev_hs;
 	reg [15:0] h_cnt, line_len, hs_len;
 


### PR DESCRIPTION
These items show up as compile errors when compiling in Vivado:
- blocks with locally declared signals need to be named blocks
- signals which are written to from always-blocks need to be `reg` type
- array size with single digit is only allowed in system verilog