### PR TITLE
arcad_video.v: support for 6 bits per color

### DIFF
--- a/sys/arcade_video.v
+++ b/sys/arcade_video.v
@@ -99,6 +99,11 @@ generate
 		assign G = {RGB_fix[7:4],RGB_fix[7:4]};
 		assign B = {RGB_fix[3:0],RGB_fix[3:0]};
 	end
+	else if(DW == 18) begin
+		assign R = {RGB_fix[17:12],RGB_fix[17:16]};
+		assign G = {RGB_fix[11: 6],RGB_fix[11:10]};
+		assign B = {RGB_fix[ 5: 0],RGB_fix[ 5: 4]};
+	end
 	else begin // 24
 		assign R = RGB_fix[23:16];
 		assign G = RGB_fix[15:8];


### PR DESCRIPTION
Support for 6 bit per color in the arcade video module. It follows the same approach as the current ones.

This is needed for SEGA systems that use the [315-5242](https://github.com/furrtek/SiliconRE/blob/master/Sega/315-5242/315-5242_schematic.png), which takes 5 bits and then a bright/dim/normal setting. It can be modeled using 6 bits.