### PR TITLE
CMD24 (state WR_STATE_SEND_DRESP) fix

### DIFF
--- a/sys/sd_card.sv
+++ b/sys/sd_card.sv
@@ -61,7 +61,7 @@ localparam SW = SZ-1;
 wire [7:0] DATA_TOKEN_CMD25    = 8'hfc;
 wire [7:0] STOP_TRAN           = 8'hfd;
 wire [7:0] DATA_TOKEN          = 8'hfe;
-wire [7:0] WRITE_DATA_RESPONSE = 8'h05;
+wire [7:0] WRITE_DATA_RESPONSE = 8'he5;
 
 // number of bytes to wait after a command before sending the reply
 localparam NCR = 5+3; // 5 bytes are required (command length)

--- a/sys/sd_card.sv
+++ b/sys/sd_card.sv
@@ -58,10 +58,10 @@ localparam DW = WIDE  ? 15 : 7;
 localparam SZ = OCTAL ?  8 : 1;
 localparam SW = SZ-1;
 
-wire [7:0] DATA_TOKEN_CMD25    = 8'hfc;
-wire [7:0] STOP_TRAN           = 8'hfd;
-wire [7:0] DATA_TOKEN          = 8'hfe;
-wire [7:0] WRITE_DATA_RESPONSE = 8'he5;
+localparam DATA_TOKEN_CMD25    = 8'hfc;
+localparam STOP_TRAN           = 8'hfd;
+localparam DATA_TOKEN          = 8'hfe;
+localparam WRITE_DATA_RESPONSE = 8'he5;
 
 // number of bytes to wait after a command before sending the reply
 localparam NCR = 5+3; // 5 bytes are required (command length)


### PR DESCRIPTION
The response code from module sd_card sent at the end of executing CMD24 (state WR_STATE_SEND_DRESP), was not a byte starting with bits 1110 as expected by the sd_controller module. This caused the sd_controller to assume the result byte is finished and switch off the clock signal prematurely. After that the system could not recover and return to a working state.