### PR TITLE
Fix warning regarding HDMI_BOB_DEINT

### DIFF
--- a/mycore.sv
+++ b/mycore.sv
@@ -188,6 +188,7 @@ assign VGA_SCALER  = 0;
 assign VGA_DISABLE = 0;
 assign HDMI_FREEZE = 0;
 assign HDMI_BLACKOUT = 0;
+assign HDMI_BOB_DEINT = 0;
 
 assign AUDIO_S = 0;
 assign AUDIO_L = 0;


### PR DESCRIPTION
Hushes the warning for the new bob deinterlacing option.