### PR TITLE
New feature signaling F12 key should be passed to core

### DIFF
--- a/sys/hps_io.sv
+++ b/sys/hps_io.sv
@@ -166,7 +166,12 @@ module hps_io #(parameter CONF_STR, CONF_STR_BRAM=0, PS2DIV=0, WIDE=0, VDNUM=1, 
 	output reg [31:0] uart_speed,
 
 	// for core-specific extensions
-	inout      [35:0] EXT_BUS
+	inout      [35:0] EXT_BUS,
+	
+	// is modifier key requested to raise fremework menu? 
+	//  0 - no, F12 bring framework menu
+	//  1 - F12 is passed to core, F12 + (L/R)GUI key bring framework menu
+	input             f12_key_menu_mod
 );
 
 assign EXT_BUS[31:16] = HPS_BUS[31:16];
@@ -335,6 +340,8 @@ always@(posedge clk_sys) begin : uio_block
 				  'h36: begin io_dout <= info_n; info_n <= 0; end
 				  'h39: io_dout <= 1;
 				  'h3C: if(upload_req) begin io_dout <= {ioctl_upload_index, 8'd1}; upload_req <= 0; end
+				  'h43: io_dout <= f12_key_menu_mod;
+				  
 				  'h3E: io_dout <= 1; // shadow mask
 				'h003F: io_dout <= joystick_0_rumble;
 				'h013F: io_dout <= joystick_1_rumble;

--- a/sys/hps_io.sv
+++ b/sys/hps_io.sv
@@ -26,8 +26,13 @@
 // WIDE=1 for 16 bit file I/O
 // VDNUM 1..10
 // BLKSZ 0..7: 0 = 128, 1 = 256, 2 = 512(default), .. 7 = 16384
+
+// F12KEYMOD - is modifier key requested to raise fremework menu? 
+//  0 - no, F12 bring framework menu
+//  1 - F12 is passed to core, F12 + (L/R)GUI key bring framework menu
+
 //
-module hps_io #(parameter CONF_STR, CONF_STR_BRAM=0, PS2DIV=0, WIDE=0, VDNUM=1, BLKSZ=2, PS2WE=0, STRLEN=$size(CONF_STR)>>3)
+module hps_io #(parameter CONF_STR, CONF_STR_BRAM=0, PS2DIV=0, WIDE=0, VDNUM=1, BLKSZ=2, PS2WE=0, STRLEN=$size(CONF_STR)>>3, F12KEYMOD=0)
 (
 	input             clk_sys,
 	inout      [48:0] HPS_BUS,
@@ -166,12 +171,7 @@ module hps_io #(parameter CONF_STR, CONF_STR_BRAM=0, PS2DIV=0, WIDE=0, VDNUM=1, 
 	output reg [31:0] uart_speed,
 
 	// for core-specific extensions
-	inout      [35:0] EXT_BUS,
-	
-	// is modifier key requested to raise fremework menu? 
-	//  0 - no, F12 bring framework menu
-	//  1 - F12 is passed to core, F12 + (L/R)GUI key bring framework menu
-	input             f12_key_menu_mod
+	inout      [35:0] EXT_BUS
 );
 
 assign EXT_BUS[31:16] = HPS_BUS[31:16];
@@ -339,8 +339,8 @@ always@(posedge clk_sys) begin : uio_block
 				  'h32: io_dout <= gamma_bus[21];
 				  'h36: begin io_dout <= info_n; info_n <= 0; end
 				  'h39: io_dout <= 1;
-				  'h3C: if(upload_req) begin io_dout <= {ioctl_upload_index, 8'd1}; upload_req <= 0; end
-				  'h43: io_dout <= f12_key_menu_mod;
+				  'h3C: if(upload_req) begin io_dout <= {ioctl_upload_index, 8'd1}; upload_req <= 0; end				  
+				  'h43: io_dout <= F12KEYMOD;
 				  
 				  'h3E: io_dout <= 1; // shadow mask
 				'h003F: io_dout <= joystick_0_rumble;


### PR DESCRIPTION
This patch allow core to signal to framework that F12 should be passed to core (as is done for 486, PCXT or Archie cores). Signaling is done without need to modify MiSTer main. I do believe this is cleaner solution. Currently I do have one core that needs F12 in a core (PMD85) and in future I might have one or two more....

There is linked pull request on a MiSTer main repository

Below there is an example how core can request for F12. If this "line" is not present default behavior is same as now.
Please mind there is a hard-coded exception for recent cores that need F12 (no need to update them).
`hps_io #(.CONF_STR(CONF_STR)) hps_io
(
....
	.f12_key_menu_mod(1)
);`