### PR TITLE
ioctl_rd fix from the recent Atari800 core work

### DIFF
--- a/sys/hps_io.sv
+++ b/sys/hps_io.sv
@@ -673,7 +673,6 @@ always@(posedge clk_sys) begin : fio_block
 								0:	if(io_din[7:0] == 8'hAA) begin
 										ioctl_addr <= 0;
 										ioctl_upload <= 1;
-										ioctl_rd <= 1;
 									end
 									else if(io_din[7:0]) begin
 										addr <= 0;
@@ -693,6 +692,7 @@ always@(posedge clk_sys) begin : fio_block
 								2: begin
 										ioctl_addr[26:16] <= io_din[10:0];
 										addr[26:16] <= io_din[10:0];
+										ioctl_rd <= 1;
 									end
 							endcase
 						end


### PR DESCRIPTION
This is the fix to hps_io that I mentioned in one of the recent PRs for Atari800. Unless I am totally mistaken and use the interface wrong, the ioctl_rd should only be set once the address is initialized, otherwise the first upload is always from address 0. (None of the code in the Main seem to try to use an address != 0 for uploading, the Atari800 core was the first one to do it).