### PR TITLE
audio_out: replace multi-bit 2-FF sync with MCP formulation

### DIFF
--- a/sys/audio_out.v
+++ b/sys/audio_out.v
@@ -23,6 +23,7 @@ module audio_out
 	input  [1:0] mix,
 
 	input        is_signed,
+	input        clk_core,
 	input [15:0] core_l,
 	input [15:0] core_r,
 
@@ -140,16 +141,31 @@ always @(posedge clk) begin
 	end
 end
 
-reg [15:0] cl,cr;
+// MCP formulation for multi-bit CDC
+reg [15:0] core_l_r = 0, core_r_r = 0;
+reg [15:0] core_l_prev = 0, core_r_prev = 0;
+reg        core_tog = 0;
+always @(posedge clk_core) begin
+	core_l_r    <= core_l;
+	core_r_r    <= core_r;
+	core_l_prev <= core_l_r;
+	core_r_prev <= core_r_r;
+	if (core_l_prev != core_l_r || core_r_prev != core_r_r)
+		core_tog <= ~core_tog;
+end
+
+reg [15:0] cl = 0, cr = 0;
 always @(posedge clk) begin
-	reg [15:0] cl1,cl2;
-	reg [15:0] cr1,cr2;
+	reg tog_s1, tog_s2, tog_prev;
 
-	cl1 <= core_l; cl2 <= cl1;
-	if(cl2 == cl1) cl <= cl2;
+	tog_s1   <= core_tog;
+	tog_s2   <= tog_s1;
+	tog_prev <= tog_s2;
 
-	cr1 <= core_r; cr2 <= cr1;
-	if(cr2 == cr1) cr <= cr2;
+	if (tog_s2 ^ tog_prev) begin
+		cl <= core_l_r;
+		cr <= core_r_r;
+	end
 end
 
 reg a_en1 = 0, a_en2 = 0;

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -1584,6 +1584,7 @@ audio_out audio_out
 	.cy2(acy2),
 
 	.is_signed(audio_s),
+	.clk_core(clk_sys),
 	.core_l(audio_l),
 	.core_r(audio_r),
 


### PR DESCRIPTION
The previous approach synced each of the audio bits through a 2-FF chain, then checked cl2 == cl1 for stability. Per Cummings' CDC paper, this is unsafe for multi-bit signals. Individual bits can resolve from different source clock cycles due to skew, producing a corrupted sample that still passes the equality check.

This could have potentially led to distortion, clicks, pops over audio. I am not 100% sure this solves any issue, but it might be one piece of the puzzle in resolving some noted audio issues in various cores due to distortion and popping that appear to be related to metastability.

Source, see 5.6.1: [2008-Clock Domain Crossing (CDC) Design & Verification Techniques Using SystemVerilog.pdf](https://github.com/user-attachments/files/26010948/2008-Clock.Domain.Crossing.CDC.Design.Verification.Techniques.Using.SystemVerilog.pdf)

I'm open to changing this method to an asynchronous FIFO instead which should help with timing closure and metastability as well, but the closed-loop MCP method is supposed to be more robust. An async FIFO would use a little more logic, but would introduce less latency.