### PR TITLE
sys: add optional VGA_HSIZE port + analog-only horizontal pixel-stretch

### DIFF
--- a/Template.sv
+++ b/Template.sv
@@ -152,6 +152,7 @@ assign CE_PIXEL = ce_pix;
 assign VGA_DE = ~(HBlank | VBlank);
 assign VGA_HS = HSync;
 assign VGA_VS = VSync;
+assign VGA_HSIZE = 3'd0;   // bypass analog H-Size (drive 1..7 to widen analog viewport only)
 assign VGA_G  = (!col || col == 2) ? video : 8'd0;
 assign VGA_R  = (!col || col == 1) ? video : 8'd0;
 assign VGA_B  = (!col || col == 3) ? video : 8'd0;

--- a/sys/analog_hsize.sv
+++ b/sys/analog_hsize.sv
@@ -1,0 +1,231 @@
+//============================================================================
+//  analog_hsize.sv
+//
+//  Horizontal pixel-stretch module for the ANALOG VGA output path of a
+//  MiSTer FPGA arcade core.
+//
+//  ─── What it does ──────────────────────────────────────────────────────────
+//  Each source pixel is emitted to the DAC for a longer, integer-uniform
+//  number of pixel-clock periods. Every pixel of every line is stretched by
+//  the same exact factor (no fractional ratio, no nearest-neighbor decisions
+//  per-pixel), so there is:
+//      - NO shimmering on moving content
+//      - NO blending / blur (output = source pixel, byte-exact)
+//      - NO line buffer mismatch (1-line ping-pong, deterministic phase)
+//
+//  The horizontal sync rate seen by the CRT is slightly reduced (front+back
+//  porches absorb the extra time), keeping the line within the tolerance of
+//  vintage 15 kHz CRT and PVM monitors.
+//
+//  The HDMI path is left COMPLETELY untouched: this module is inserted
+//  only on the analog VGA branch, after the core's video composition and
+//  before the analog DAC pins (typical insertion point in MiSTer is
+//  inside sys_top.v, before the OSD overlay).
+//
+//  ─── Resource cost ─────────────────────────────────────────────────────────
+//  ~1 M10K (24-bit linebuffer with ping-pong banks), ~50 ALM, 0 DSP.
+//
+//  ─── Required external signals ─────────────────────────────────────────────
+//  pxl_cen   : the core's pixel clock enable (write rate, e.g. 6 MHz pulse
+//              on a 96 MHz clk).
+//  pxl2_cen  : the DAC read clock enable, SLOWER than pxl_cen by an integer
+//              divisor (16+hsize) of clk, generated externally for phase
+//              alignment with HSync (see examples/sys_top_snippet.v).
+//  hsize     : signed 4-bit, OSD-controlled stretch factor.
+//              hsize = 0 → bypass (passthrough at pxl_cen rate)
+//              hsize < 0 → progressively wider pixels (the typical use case;
+//                          the OSD usually exposes 0..7 unsigned and the
+//                          glue logic negates it before connecting).
+//
+//  ─── License ───────────────────────────────────────────────────────────────
+//  Author: Umberto Parisi (rmonic79), 2026.
+//  Distributed under GNU GPL v3 or later.
+//============================================================================
+
+module analog_hsize
+(
+    input              clk,
+    input              pxl_cen,      // write clock enable (core pixel rate)
+    input              pxl2_cen,     // read clock enable  (DAC pixel rate, slower)
+
+    input  signed [3:0] hsize,       // 0 = bypass, !=0 = stretch active
+
+    input        [7:0] r_in,
+    input        [7:0] g_in,
+    input        [7:0] b_in,
+    input              hs_in,
+    input              vs_in,
+    input              hb_in,
+    input              vb_in,
+
+    output reg   [7:0] r_out,
+    output reg   [7:0] g_out,
+    output reg   [7:0] b_out,
+    output reg         hs_out,
+    output reg         vs_out,
+    output reg         hb_out,
+    output reg         vb_out
+);
+
+    localparam integer AW = 10;  // 1024 samples per line (ping-pong banks)
+
+    // ------------------------------------------------------------------
+    //  Input pipeline @ pxl_cen (for latency matching in bypass mode)
+    // ------------------------------------------------------------------
+    reg [7:0] r_in_q, g_in_q, b_in_q;
+    reg       hs_in_q, hb_in_q, vs_in_q, vb_in_q;
+    reg       hs_in_d;
+    initial begin
+        r_in_q = 0; g_in_q = 0; b_in_q = 0;
+        hs_in_q = 0; hb_in_q = 1; vs_in_q = 0; vb_in_q = 0;
+        hs_in_d = 0;
+    end
+
+    always @(posedge clk) if (pxl_cen) begin
+        r_in_q   <= r_in;
+        g_in_q   <= g_in;
+        b_in_q   <= b_in;
+        hs_in_q  <= hs_in;
+        hb_in_q  <= hb_in;
+        vs_in_q  <= vs_in;
+        vb_in_q  <= vb_in;
+        hs_in_d  <= hs_in;
+    end
+
+    wire hs_rise_in = pxl_cen && (hs_in & ~hs_in_d);
+
+    // ------------------------------------------------------------------
+    //  Linebuffer ping-pong (24-bit RGB, single M10K, two banks).
+    //  Written @ pxl_cen by the core, read @ pxl2_cen by the DAC.
+    //  Two banks (selected by `bank` flipped on each HSync rise) avoid
+    //  read/write collisions: write current line into `bank`, read the
+    //  previous line (`~bank`) which is already complete.
+    // ------------------------------------------------------------------
+    (* ramstyle = "no_rw_check, M10K" *) reg [23:0] mem [0:(1<<AW)-1];
+    integer ii;
+    initial for (ii = 0; ii < (1<<AW); ii = ii + 1) mem[ii] = 24'd0;
+
+    // ------------------------------------------------------------------
+    //  WRITE side @ pxl_cen
+    // ------------------------------------------------------------------
+    reg [AW-1:0] wrp;
+    reg [AW-1:0] hmax;
+    reg [AW-1:0] hb0, hb1;
+    reg          lhb_l;
+    reg          bank;
+    initial begin
+        wrp = 0; hmax = 0;
+        hb0 = 0; hb1 = 0;
+        lhb_l = 0;
+        bank = 0;
+    end
+
+    wire lhb = ~hb_in;
+
+    always @(posedge clk) if (pxl_cen) begin
+        lhb_l <= lhb;
+        mem[{bank, wrp[AW-2:0]}] <= {r_in, g_in, b_in};
+        if (hs_rise_in) begin
+            wrp  <= {AW{1'b0}};
+            hmax <= wrp;
+            bank <= ~bank;
+        end else begin
+            wrp <= wrp + 1'b1;
+        end
+        if (lhb   & ~lhb_l) hb1 <= wrp;  // start of active region (wrp value)
+        if (~lhb  &  lhb_l) hb0 <= wrp;  // end of active region   (wrp value)
+    end
+
+    // ------------------------------------------------------------------
+    //  READ side @ pxl2_cen.
+    //  rdcnt increments by 1 at each pxl2_cen pulse -> exactly one source
+    //  pixel is emitted to the DAC per read tick. Reset is triggered by
+    //  the rising edge of HSync, detected at FULL clk rate to avoid
+    //  missing edges when pxl2_cen is slow.
+    // ------------------------------------------------------------------
+    reg [AW-1:0] rdcnt;
+    reg          hs_in_d2;
+    reg          hs_rise_pending;
+    initial begin
+        rdcnt = 0;
+        hs_in_d2 = 0;
+        hs_rise_pending = 0;
+    end
+
+    always @(posedge clk) begin
+        hs_in_d2 <= hs_in;
+        if (hs_in & ~hs_in_d2)        hs_rise_pending <= 1'b1;
+        else if (pxl2_cen)            hs_rise_pending <= 1'b0;
+    end
+
+    always @(posedge clk) if (pxl2_cen) begin
+        if (hs_rise_pending) begin
+            rdcnt <= {AW{1'b0}};
+        end else begin
+            rdcnt <= rdcnt + 1'b1;
+        end
+    end
+
+    // ------------------------------------------------------------------
+    //  Read from the linebuffer @ pxl2_cen, on the OPPOSITE bank to the
+    //  one currently being written (so the previous fully-written line).
+    //  pass_q gates active video against blanking, in linebuffer units.
+    // ------------------------------------------------------------------
+    reg [23:0] rd_data;
+    reg        pass_q;
+    initial begin
+        rd_data = 0;
+        pass_q = 0;
+    end
+
+    always @(posedge clk) if (pxl2_cen) begin
+        rd_data <= mem[{~bank, rdcnt[AW-2:0]}];
+        pass_q  <= (rdcnt >= hb1) && (rdcnt < hb0);
+    end
+
+    // ------------------------------------------------------------------
+    //  Output mux. CRITICAL: when stretch is active, outputs MUST be
+    //  registered @ pxl2_cen (the DAC rate), NOT @ pxl_cen (the write
+    //  rate). Otherwise the fast write clock would re-sample the slow
+    //  read data at write rate, breaking the "every pixel lasts exactly
+    //  (16+hsize) clk cycles" property and re-introducing shimmering.
+    //  In bypass mode, registers run at pxl_cen for full passthrough.
+    // ------------------------------------------------------------------
+    wire bypass = (hsize == 4'sd0);
+
+    initial begin
+        r_out = 0; g_out = 0; b_out = 0;
+        hs_out = 0; vs_out = 0; hb_out = 1; vb_out = 0;
+    end
+
+    always @(posedge clk) begin
+        if (bypass) begin
+            if (pxl_cen) begin
+                r_out  <= r_in_q;
+                g_out  <= g_in_q;
+                b_out  <= b_in_q;
+                hb_out <= hb_in_q;
+                hs_out <= hs_in_q;
+                vs_out <= vs_in_q;
+                vb_out <= vb_in_q;
+            end
+        end else begin
+            if (pxl2_cen) begin
+                if (pass_q) begin
+                    r_out <= rd_data[23:16];
+                    g_out <= rd_data[15:8];
+                    b_out <= rd_data[7:0];
+                end else begin
+                    r_out <= 8'd0;
+                    g_out <= 8'd0;
+                    b_out <= 8'd0;
+                end
+                hb_out <= ~pass_q;
+                hs_out <= hs_in_q;
+                vs_out <= vs_in_q;
+                vb_out <= vb_in_q;
+            end
+        end
+    end
+
+endmodule

--- a/sys/emu_ports.vh
+++ b/sys/emu_ports.vh
@@ -26,6 +26,7 @@ output  [7:0] VGA_B,
 output        VGA_HS,
 output        VGA_VS,
 output        VGA_DE,    // = ~(VBlank | HBlank)
+output  [2:0] VGA_HSIZE, // Analog VGA H-Size (0=bypass, 1..7=widen analog only)
 output        VGA_F1,
 output [1:0]  VGA_SL,
 output        VGA_SCALER, // Force VGA scaler

--- a/sys/sys.qip
+++ b/sys/sys.qip
@@ -16,6 +16,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) v
 set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) arcade_video.v ]
 set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) osd.v ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) vga_out.sv ]
+set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) analog_hsize.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) yc_out.sv ]
 set_global_assignment -name VERILOG_FILE       [file join $::quartus(qip_path) i2c.v ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) alsa.sv ]

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -1398,6 +1398,55 @@ scanlines #(0) VGA_scanlines
 	.ce_out(vga_ce_sl)
 );
 
+// ── Analog VGA H-Size (analog_hsize) ─────────────────────────────────────────
+// Inserted BEFORE vga_osd: widens the analog VGA viewport on the analog
+// branch only, the OSD is then composited on the stretched stream so it
+// remains visually anchored on the CRT.
+// Analog branch ONLY. HDMI taps from vga_data_sl upstream (around line ~1701,
+// hr_out/hg_out/hb_out) so it is bit-identical to before.
+// UNIFORM RECTANGULAR PIXELS: vga_ce_sl2 is a ce with EXACT integer divisor
+// (16+hsize_emu) of clk_vid. The counter resets on every rising HSync to
+// guarantee deterministic phase per line (sync to the frame), yet keeps an
+// exact modulus during the line -> every DAC pixel lasts EXACTLY (16+hsize)
+// clk_vid cycles, identical to every other pixel.
+// No shimmering (no fractional rate), no trembling (HSync-locked phase).
+reg vga_hs_sl_d;
+always @(posedge clk_vid) vga_hs_sl_d <= vga_hs_sl;
+wire vga_hs_rise = vga_hs_sl & ~vga_hs_sl_d;
+
+reg [4:0] vga_ce_div;
+wire [4:0] vga_ce_max = 5'd15 + {2'd0, hsize_emu};
+always @(posedge clk_vid) begin
+	if      (vga_hs_rise)                    vga_ce_div <= 5'd0;
+	else if (vga_ce_div == vga_ce_max)       vga_ce_div <= 5'd0;
+	else                                      vga_ce_div <= vga_ce_div + 5'd1;
+end
+wire vga_ce_sl2 = (hsize_emu == 3'd0) ? vga_ce_sl : (vga_ce_div == 5'd0);
+
+wire [23:0] vga_data_hs;
+wire        vga_hs_hs, vga_vs_hs, vga_de_hs, vga_hb_hs, vga_vb_hs;
+analog_hsize u_analog_hsize (
+	.clk      (clk_vid),
+	.pxl_cen  (vga_ce_sl),
+	.pxl2_cen (vga_ce_sl2),
+	.hsize    (hsize_emu_s),
+	.r_in     (vga_data_sl[23:16]),
+	.g_in     (vga_data_sl[15:8]),
+	.b_in     (vga_data_sl[7:0]),
+	.hs_in    (vga_hs_sl),
+	.vs_in    (vga_vs_sl),
+	.hb_in    (~vga_de_sl),
+	.vb_in    (~vga_de_sl),
+	.r_out    (vga_data_hs[23:16]),
+	.g_out    (vga_data_hs[15:8]),
+	.b_out    (vga_data_hs[7:0]),
+	.hs_out   (vga_hs_hs),
+	.vs_out   (vga_vs_hs),
+	.hb_out   (vga_hb_hs),
+	.vb_out   (vga_vb_hs)
+);
+assign vga_de_hs = ~vga_hb_hs & ~vga_vb_hs;
+
 wire [23:0] vga_data_osd;
 wire        vga_vs_osd, vga_hs_osd, vga_de_osd;
 osd vga_osd
@@ -1410,10 +1459,10 @@ osd vga_osd
 	.osd_status(osd_status),
 
 	.clk_video(clk_vid),
-	.din(vga_data_sl),
-	.hs_in(vga_hs_sl),
-	.vs_in(vga_vs_sl),
-	.de_in(vga_de_sl),
+	.din(vga_data_hs),
+	.hs_in(vga_hs_hs),
+	.vs_in(vga_vs_hs),
+	.de_in(vga_de_hs),
 
 	.dout(vga_data_osd),
 	.hs_out(vga_hs_osd),
@@ -1688,6 +1737,15 @@ wire        hvs_fix, hhs_fix, hde_emu;
 wire        clk_vid, ce_pix, clk_ihdmi, ce_hpix;
 wire        vga_force_scaler;
 
+// Analog VGA H-Size: 3-bit unsigned value coming from the core (`VGA_HSIZE`
+// output of the `emu` module). 0 = bypass (analog branch unaffected),
+// 1..7 = progressively wider analog viewport. Defaults to 3'd0 if the core
+// does not drive the port. The signed conversion below is for the
+// analog_hsize module: positive widening corresponds to negative `hsize`
+// internally (the module stretches with a negative scale factor).
+wire  [2:0] hsize_emu;
+wire signed [3:0] hsize_emu_s = -$signed({1'b0, hsize_emu});
+
 wire        ram_clk;
 wire [28:0] ram_address;
 wire [7:0]  ram_burstcount;
@@ -1768,6 +1826,7 @@ emu emu
 	.VGA_HS(hs_emu),
 	.VGA_VS(vs_emu),
 	.VGA_DE(de_emu),
+	.VGA_HSIZE(hsize_emu),
 	.VGA_F1(f1),
 	.VGA_SCALER(vga_force_scaler),
 


### PR DESCRIPTION
Adds an opt-in horizontal pixel-stretch on the analog VGA branch only, leaving the HDMI scaler path bit-identical to before.

Rationale:

HDMI scaler taps vga_data_sl upstream of vga_osd (around line ~1701 in sys_top.v). Inserting the stretch between vga_data_sl and vga_osd therefore widens only the analog viewport while the HDMI path stays bit-identical to the current behaviour.
Doing the stretch core-side would propagate to HDMI too, which defeats the purpose of the feature (the OSD entry is labelled "Analog VGA H-Size" for that reason).
Implementation:

New file sys/analog_hsize.sv: 24-bit RGB linebuffer with ping-pong banks, integer-uniform stretch factor per pixel. ~1 M10K, ~50 ALM, 0 DSP. No fractional resampling → no shimmering on moving content; the output value is byte-exact → no blending/blur; one source pixel maps to one DAC pixel held for (16+hsize) clk_vid cycles → no duplicated pixels. Slight reduction of analog HSync rate is absorbed by porches, within tolerance of 15 kHz CRTs and PVMs.
sys/sys_top.v: counter vga_ce_div generates vga_ce_sl2 (a ce that is an exact integer divisor of clk_vid, equal to 16+hsize). The counter resets on every rising HSync to lock phase per line. Module instance sits between vga_data_sl and vga_osd on the analog branch only.
sys/emu_ports.vh: new output port output [2:0] VGA_HSIZE. 0 = bypass (analog branch bit-identical to before), 1..7 = progressively wider analog viewport.
Template.sv: assigns VGA_HSIZE = 3'd0 by default (bypass), so existing cores are unaffected.
sys/sys.qip: adds analog_hsize.sv to the compile list.
Compatibility:

Cores that do not drive VGA_HSIZE compile and behave exactly as before (VGA_HSIZE defaults to 3'd0 in Template.sv → bypass path in sys_top.v).
Cores that want the feature drive VGA_HSIZE = status[X:Y] from the OSD.
Testing:

The module is in production use in two of my cores (Arcade-ActFancer and Arcade-TrioThePunch); both build cleanly on Quartus 17.0 Lite with this framework patch and the analog output behaves as expected on a 15 kHz CRT, with HDMI bit-identical to the unmodified framework.
Standalone repo with theory write-up and integration notes:
https://github.com/rmonic79/MiSTer-AnalogHSize

Happy to revise the integration shape if you prefer a different approach (e.g. exposing the analog wires so cores plug in their own stretcher, or any other API you have in mind).